### PR TITLE
The variable `companyName` is deprecated by ElectronJS

### DIFF
--- a/introduction/getting-started/integrations/cross-platform/electron.md
+++ b/introduction/getting-started/integrations/cross-platform/electron.md
@@ -35,7 +35,6 @@ Note that the `globalExtra` fields will be sent with crashes captured on all pro
 ```javascript
 const electron = require('electron')
 electron.crashReporter.start({
-  companyName: '<<company name>>',
   productName: '<<product name>>',
   submitURL: 'https://<<database name>>.bugsplat.com/post/electron/crash.php',
   compress: true,


### PR DESCRIPTION
### Description
The option has been marked as deprecated in the Crash Reporter in ElectronJS's documentation at:
https://www.electronjs.org/docs/latest/api/crash-reporter

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
