### PR TITLE
Add User Feedback docs for Android SDK

### DIFF
--- a/introduction/getting-started/integrations/cross-platform/java.md
+++ b/introduction/getting-started/integrations/cross-platform/java.md
@@ -70,6 +70,20 @@ class MyThreadGroup extends ThreadGroup {
 }
 ```
 
+### 💬 User Feedback
+
+In addition to crash reporting, BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```java
+BugSplat.postFeedback("Login button broken");
+```
+
+You can also provide a description:
+
+```java
+BugSplat.postFeedback("Login button broken", "Nothing happens when I tap it");
+```
+
 ### 🗺️ Samples
 
 This repo includes sample projects that demonstrate how to integrate `bugsplat-java`. Please review the [my-java-crasher](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher) and [my-java-crasher-console](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher-console) folders for more a sample implementation. To run the sample projects, clone this repo and open it in either [IntelliJ IDEA](https://www.jetbrains.com/idea/) or [VS Code](https://code.visualstudio.com/).

--- a/introduction/getting-started/integrations/cross-platform/java.md
+++ b/introduction/getting-started/integrations/cross-platform/java.md
@@ -70,46 +70,6 @@ class MyThreadGroup extends ThreadGroup {
 }
 ```
 
-### 💬 User Feedback
-
-In addition to crash reporting, BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
-
-```java
-BugSplat.postFeedback("Login button broken");
-```
-
-You can also provide a description and optional settings via `BugSplatPostOptions`:
-
-```java
-BugSplat.postFeedback(
-    "Login button broken",
-    "Nothing happens when I tap it",
-    new BugSplatPostOptions() {{
-        setEmail("jane@example.com");
-        setUser("Jane");
-        setKey("en-US");
-    }}
-);
-```
-
-To include file attachments such as screenshots or log files:
-
-```java
-List<File> attachments = Arrays.asList(
-    new File("/path/to/screenshot.png"),
-    new File("/path/to/log.txt")
-);
-BugSplat.postFeedback(
-    "Login button broken",
-    "Nothing happens when I tap it",
-    new BugSplatPostOptions() {{
-        setEmail("jane@example.com");
-        setUser("Jane");
-    }},
-    attachments
-);
-```
-
 ### 🗺️ Samples
 
 This repo includes sample projects that demonstrate how to integrate `bugsplat-java`. Please review the [my-java-crasher](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher) and [my-java-crasher-console](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher-console) folders for more a sample implementation. To run the sample projects, clone this repo and open it in either [IntelliJ IDEA](https://www.jetbrains.com/idea/) or [VS Code](https://code.visualstudio.com/).

--- a/introduction/getting-started/integrations/cross-platform/java.md
+++ b/introduction/getting-started/integrations/cross-platform/java.md
@@ -78,10 +78,36 @@ In addition to crash reporting, BugSplat supports collecting non-crashing user f
 BugSplat.postFeedback("Login button broken");
 ```
 
-You can also provide a description:
+You can also provide a description and optional settings via `BugSplatPostOptions`:
 
 ```java
-BugSplat.postFeedback("Login button broken", "Nothing happens when I tap it");
+BugSplat.postFeedback(
+    "Login button broken",
+    "Nothing happens when I tap it",
+    new BugSplatPostOptions() {{
+        setEmail("jane@example.com");
+        setUser("Jane");
+        setKey("en-US");
+    }}
+);
+```
+
+To include file attachments such as screenshots or log files:
+
+```java
+List<File> attachments = Arrays.asList(
+    new File("/path/to/screenshot.png"),
+    new File("/path/to/log.txt")
+);
+BugSplat.postFeedback(
+    "Login button broken",
+    "Nothing happens when I tap it",
+    new BugSplatPostOptions() {{
+        setEmail("jane@example.com");
+        setUser("Jane");
+    }},
+    attachments
+);
 ```
 
 ### 🗺️ Samples

--- a/introduction/getting-started/integrations/mobile/android.md
+++ b/introduction/getting-started/integrations/mobile/android.md
@@ -184,6 +184,20 @@ private fun writeLogFile() {
 }
 ```
 
+### User Feedback
+
+In addition to native crash reporting via Crashpad, the BugSplat Android SDK supports collecting non-crashing user feedback such as bug reports and feature requests from the Java layer. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```java
+import com.bugsplat.android.BugSplat;
+
+// Async (spawns a background thread)
+BugSplat.postFeedback(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+
+// Synchronous (call from your own background thread)
+BugSplat.postFeedbackBlocking(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+```
+
 ### Symbols
 
 To ensure that your crash reports contain function names and line numbers you'll need to add an option to your build configuration that prevents symbolic information from being stripped. To prevent symbols from being stripped, add the following to your `build.gradle` file:

--- a/introduction/getting-started/integrations/mobile/android.md
+++ b/introduction/getting-started/integrations/mobile/android.md
@@ -192,10 +192,26 @@ In addition to native crash reporting via Crashpad, the BugSplat Android SDK sup
 import com.bugsplat.android.BugSplat;
 
 // Async (spawns a background thread)
-BugSplat.postFeedback(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+BugSplat.postFeedback(database, application, version,
+    "Login button broken", "Nothing happens when I tap it",
+    "Jane", "jane@example.com", "en-US");
 
 // Synchronous (call from your own background thread)
-BugSplat.postFeedbackBlocking(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+boolean success = BugSplat.postFeedbackBlocking(database, application, version,
+    "Login button broken", "Nothing happens when I tap it",
+    "Jane", "jane@example.com", "en-US");
+```
+
+To include file attachments such as screenshots or log files:
+
+```java
+List<File> attachments = Arrays.asList(
+    new File("/path/to/screenshot.png"),
+    new File("/path/to/log.txt")
+);
+BugSplat.postFeedback(database, application, version,
+    "Login button broken", "Nothing happens when I tap it",
+    "Jane", "jane@example.com", "en-US", attachments);
 ```
 
 ### Symbols


### PR DESCRIPTION
## Summary
- Adds a "User Feedback" section to the Java and Android SDK documentation pages
- Documents `postFeedback` API usage
- Corresponds to SDK PRs: bugsplat-java#8, bugsplat-android#8

## Test plan
- [ ] Verify the new sections render correctly in GitBook
- [ ] Verify code snippets are accurate and match the SDK APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)