### PR TITLE
docs: add SetAttribute usage for Unreal iOS and Android

### DIFF
--- a/introduction/getting-started/integrations/game-development/unreal-engine/unreal-engine-plugin.md
+++ b/introduction/getting-started/integrations/game-development/unreal-engine/unreal-engine-plugin.md
@@ -264,6 +264,26 @@ void UMyUnrealCrasherGameInstance::Init()
 
 </details>
 
+**Setting Attributes (iOS and Android)**
+
+The BugSplat plugin automatically adds several attributes from the crash context at initialization time. These attributes are not updated automatically after initialization. If you'd like to update them or add new ones, use the `SetAttribute` and `RemoveAttribute` functions.
+
+To call `SetAttribute` from C++, add `BugSplatRuntime` to your module's `PrivateDependencyModuleNames` in your `.Build.cs` file:
+
+```csharp
+PrivateDependencyModuleNames.AddRange(new string[] { "BugSplatRuntime" });
+```
+
+Then include the header and call `SetAttribute`:
+
+```cpp
+#include "BugSplatAttributes.h"
+
+UBugSplatAttributes::SetAttribute(TEXT("userId"), TEXT("12345"));
+```
+
+`SetAttribute` is also available as a Blueprint node under the BugSplat category.
+
 #### Xbox and PlayStation
 
 BugSplat can provide instructions for implementing Unreal crash reporting on Xbox and PlayStation. Please email us at [support@bugsplat.com](mailto:support@bugsplat.com) for more info.


### PR DESCRIPTION
## Summary
- Adds documentation for `SetAttribute` and `RemoveAttribute` functions in the Unreal Engine plugin's iOS and Android section
- Includes `Build.cs` dependency setup, C++ usage example, and Blueprint availability note

## Test plan
- [x] Verify the markdown renders correctly on GitBook

🤖 Generated with [Claude Code](https://claude.com/claude-code)