### PR TITLE
docs(apple): document hang detection and user feedback APIs

### DIFF
--- a/introduction/getting-started/integrations/cross-platform/java.md
+++ b/introduction/getting-started/integrations/cross-platform/java.md
@@ -70,6 +70,20 @@ class MyThreadGroup extends ThreadGroup {
 }
 ```
 
+### 💬 User Feedback
+
+In addition to crash reporting, BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```java
+BugSplat.postFeedback("Login button broken");
+```
+
+You can also provide a description:
+
+```java
+BugSplat.postFeedback("Login button broken", "Nothing happens when I tap it");
+```
+
 ### 🗺️ Samples
 
 This repo includes sample projects that demonstrate how to integrate `bugsplat-java`. Please review the [my-java-crasher](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher) and [my-java-crasher-console](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher-console) folders for more a sample implementation. To run the sample projects, clone this repo and open it in either [IntelliJ IDEA](https://www.jetbrains.com/idea/) or [VS Code](https://code.visualstudio.com/).

--- a/introduction/getting-started/integrations/cross-platform/java.md
+++ b/introduction/getting-started/integrations/cross-platform/java.md
@@ -70,46 +70,6 @@ class MyThreadGroup extends ThreadGroup {
 }
 ```
 
-### 💬 User Feedback
-
-In addition to crash reporting, BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
-
-```java
-BugSplat.postFeedback("Login button broken");
-```
-
-You can also provide a description and optional settings via `BugSplatPostOptions`:
-
-```java
-BugSplat.postFeedback(
-    "Login button broken",
-    "Nothing happens when I tap it",
-    new BugSplatPostOptions() {{
-        setEmail("jane@example.com");
-        setUser("Jane");
-        setKey("en-US");
-    }}
-);
-```
-
-To include file attachments such as screenshots or log files:
-
-```java
-List<File> attachments = Arrays.asList(
-    new File("/path/to/screenshot.png"),
-    new File("/path/to/log.txt")
-);
-BugSplat.postFeedback(
-    "Login button broken",
-    "Nothing happens when I tap it",
-    new BugSplatPostOptions() {{
-        setEmail("jane@example.com");
-        setUser("Jane");
-    }},
-    attachments
-);
-```
-
 ### 🗺️ Samples
 
 This repo includes sample projects that demonstrate how to integrate `bugsplat-java`. Please review the [my-java-crasher](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher) and [my-java-crasher-console](https://github.com/BugSplat-Git/bugsplat-java/tree/master/my-java-crasher-console) folders for more a sample implementation. To run the sample projects, clone this repo and open it in either [IntelliJ IDEA](https://www.jetbrains.com/idea/) or [VS Code](https://code.visualstudio.com/).

--- a/introduction/getting-started/integrations/cross-platform/java.md
+++ b/introduction/getting-started/integrations/cross-platform/java.md
@@ -78,10 +78,36 @@ In addition to crash reporting, BugSplat supports collecting non-crashing user f
 BugSplat.postFeedback("Login button broken");
 ```
 
-You can also provide a description:
+You can also provide a description and optional settings via `BugSplatPostOptions`:
 
 ```java
-BugSplat.postFeedback("Login button broken", "Nothing happens when I tap it");
+BugSplat.postFeedback(
+    "Login button broken",
+    "Nothing happens when I tap it",
+    new BugSplatPostOptions() {{
+        setEmail("jane@example.com");
+        setUser("Jane");
+        setKey("en-US");
+    }}
+);
+```
+
+To include file attachments such as screenshots or log files:
+
+```java
+List<File> attachments = Arrays.asList(
+    new File("/path/to/screenshot.png"),
+    new File("/path/to/log.txt")
+);
+BugSplat.postFeedback(
+    "Login button broken",
+    "Nothing happens when I tap it",
+    new BugSplatPostOptions() {{
+        setEmail("jane@example.com");
+        setUser("Jane");
+    }},
+    attachments
+);
 ```
 
 ### 🗺️ Samples

--- a/introduction/getting-started/integrations/desktop/macos.md
+++ b/introduction/getting-started/integrations/desktop/macos.md
@@ -313,6 +313,67 @@ Bugsplat supports uploading attachments with crash reports. There's a delegate m
 
 Bitcode was introduced by Apple to allow apps sent to the App Store to be recompiled by Apple itself and apply the latest optimization. Bitcode has now been officially deprecated by Apple and should be removed or disabled. If Bitcode is enabled, the symbols generated for your app in the store will be different than the ones from your own build system. We recommend that you disable bitcode in order for BugSplat to reliably symbolicate crash reports. Disabling bitcode significantly simplifies symbols management and currently doesn't have any known downsides for iOS apps.
 
+#### User Feedback
+
+In addition to crash reporting, BugSplat for Apple platforms can submit non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```swift
+BugSplat.shared().postFeedback(
+    title: "Login button broken",
+    description: "Nothing happens when I tap it",
+    userName: "Jane",
+    userEmail: "jane@example.com",
+    appKey: "en-US",
+    attachments: nil
+) { error in
+    if let error = error {
+        print("Feedback failed: \(error)")
+    }
+}
+```
+
+```objectivec
+[[BugSplat shared] postFeedback:@"Login button broken"
+                    description:@"Nothing happens when I tap it"
+                       userName:@"Jane"
+                      userEmail:@"jane@example.com"
+                         appKey:@"en-US"
+                    attachments:nil
+                     completion:^(NSError * _Nullable error) {
+    if (error) {
+        NSLog(@"Feedback failed: %@", error);
+    }
+}];
+```
+
+`userName`, `userEmail`, and `appKey` fall back to the corresponding properties on `BugSplat.shared()` when passed as `nil`. To include screenshots or log files, pass an array of `BugSplatAttachment` objects in the `attachments` parameter.
+
+#### Hang Detection
+
+BugSplat can detect fatal main-thread hangs and upload them on the next launch using the same pipeline as crash reports. When enabled, BugSplat monitors the main runloop and, if it stays in the processing phase for longer than the configured threshold, persists a hang report. If the app is then terminated without the main thread recovering (a launch/resume watchdog kill or user force-quit), the report is uploaded on the next launch. Non-fatal hangs — those where the main thread eventually resumes — are discarded automatically.
+
+Enable hang detection by setting `enableHangDetection` to `YES` **before** calling `start`. `start` must be invoked on the main thread when this property is enabled.
+
+```swift
+BugSplat.shared().enableHangDetection = true
+BugSplat.shared().hangDetectionThreshold = 2.0 // optional, defaults to 2.0 seconds
+BugSplat.shared().start()
+```
+
+```objectivec
+[[BugSplat shared] setEnableHangDetection:YES];
+[[BugSplat shared] setHangDetectionThreshold:2.0]; // optional, defaults to 2.0 seconds
+[[BugSplat shared] start];
+```
+
+Hang reports carry the exception name `App Hang (Fatal)` and include attributes prefixed with `bugsplat-hang-` (duration, detection time, app state, launch id) that can be used to correlate them with crashes from the same launch.
+
+{% hint style="info" %}
+Detection is suppressed while a debugger is attached. macOS apps have no UIApplication background state, so detection runs whenever the app is launched. Command-line tools can opt in, but be aware that any code path that blocks the main thread without pumping the runloop (for example `std::getline` on stdin) will look like a hang until the runloop runs again.
+{% endhint %}
+
+The `hangDetectionThreshold` property accepts values in seconds. Typical production values are between 1.0 and 5.0 seconds. Pick a value that comfortably exceeds any work your app may legitimately do on the main thread (image decoding, JSON parsing, etc.) to avoid false positives. Values below `0.1` are clamped to `0.1`.
+
 ### Sample Applications 🧑‍🏫
 
 `Example_Apps` includes several iOS and macOS BugSplat Test apps. Integrating BugSplat only requires the xcframework and a few lines of code.

--- a/introduction/getting-started/integrations/mobile/android.md
+++ b/introduction/getting-started/integrations/mobile/android.md
@@ -184,6 +184,20 @@ private fun writeLogFile() {
 }
 ```
 
+### User Feedback
+
+In addition to native crash reporting via Crashpad, the BugSplat Android SDK supports collecting non-crashing user feedback such as bug reports and feature requests from the Java layer. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```java
+import com.bugsplat.android.BugSplat;
+
+// Async (spawns a background thread)
+BugSplat.postFeedback(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+
+// Synchronous (call from your own background thread)
+BugSplat.postFeedbackBlocking(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+```
+
 ### Symbols
 
 To ensure that your crash reports contain function names and line numbers you'll need to add an option to your build configuration that prevents symbolic information from being stripped. To prevent symbols from being stripped, add the following to your `build.gradle` file:

--- a/introduction/getting-started/integrations/mobile/android.md
+++ b/introduction/getting-started/integrations/mobile/android.md
@@ -192,10 +192,26 @@ In addition to native crash reporting via Crashpad, the BugSplat Android SDK sup
 import com.bugsplat.android.BugSplat;
 
 // Async (spawns a background thread)
-BugSplat.postFeedback(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+BugSplat.postFeedback(database, application, version,
+    "Login button broken", "Nothing happens when I tap it",
+    "Jane", "jane@example.com", "en-US");
 
 // Synchronous (call from your own background thread)
-BugSplat.postFeedbackBlocking(context, "Login button broken", "Nothing happens when I tap it", "Jane", "jane@example.com");
+boolean success = BugSplat.postFeedbackBlocking(database, application, version,
+    "Login button broken", "Nothing happens when I tap it",
+    "Jane", "jane@example.com", "en-US");
+```
+
+To include file attachments such as screenshots or log files:
+
+```java
+List<File> attachments = Arrays.asList(
+    new File("/path/to/screenshot.png"),
+    new File("/path/to/log.txt")
+);
+BugSplat.postFeedback(database, application, version,
+    "Login button broken", "Nothing happens when I tap it",
+    "Jane", "jane@example.com", "en-US", attachments);
 ```
 
 ### Symbols

--- a/introduction/getting-started/integrations/mobile/ios.md
+++ b/introduction/getting-started/integrations/mobile/ios.md
@@ -313,6 +313,67 @@ Bugsplat supports uploading attachments with crash reports. There's a delegate m
 
 Bitcode was introduced by Apple to allow apps sent to the App Store to be recompiled by Apple itself and apply the latest optimization. Bitcode has now been officially deprecated by Apple and should be removed or disabled. If Bitcode is enabled, the symbols generated for your app in the store will be different than the ones from your own build system. We recommend that you disable bitcode in order for BugSplat to reliably symbolicate crash reports. Disabling bitcode significantly simplifies symbols management and currently doesn't have any known downsides for iOS apps.
 
+#### User Feedback
+
+In addition to crash reporting, BugSplat for Apple platforms can submit non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```swift
+BugSplat.shared().postFeedback(
+    title: "Login button broken",
+    description: "Nothing happens when I tap it",
+    userName: "Jane",
+    userEmail: "jane@example.com",
+    appKey: "en-US",
+    attachments: nil
+) { error in
+    if let error = error {
+        print("Feedback failed: \(error)")
+    }
+}
+```
+
+```objectivec
+[[BugSplat shared] postFeedback:@"Login button broken"
+                    description:@"Nothing happens when I tap it"
+                       userName:@"Jane"
+                      userEmail:@"jane@example.com"
+                         appKey:@"en-US"
+                    attachments:nil
+                     completion:^(NSError * _Nullable error) {
+    if (error) {
+        NSLog(@"Feedback failed: %@", error);
+    }
+}];
+```
+
+`userName`, `userEmail`, and `appKey` fall back to the corresponding properties on `BugSplat.shared()` when passed as `nil`. To include screenshots or log files, pass an array of `BugSplatAttachment` objects in the `attachments` parameter.
+
+#### Hang Detection
+
+BugSplat can detect fatal main-thread hangs and upload them on the next launch using the same pipeline as crash reports. When enabled, BugSplat monitors the main runloop and, if it stays in the processing phase for longer than the configured threshold, persists a hang report. If the app is then terminated without the main thread recovering (a launch/resume watchdog kill or user force-quit), the report is uploaded on the next launch. Non-fatal hangs — those where the main thread eventually resumes — are discarded automatically.
+
+Enable hang detection by setting `enableHangDetection` to `YES` **before** calling `start`. `start` must be invoked on the main thread when this property is enabled.
+
+```swift
+BugSplat.shared().enableHangDetection = true
+BugSplat.shared().hangDetectionThreshold = 2.0 // optional, defaults to 2.0 seconds
+BugSplat.shared().start()
+```
+
+```objectivec
+[[BugSplat shared] setEnableHangDetection:YES];
+[[BugSplat shared] setHangDetectionThreshold:2.0]; // optional, defaults to 2.0 seconds
+[[BugSplat shared] start];
+```
+
+Hang reports carry the exception name `App Hang (Fatal)` and include attributes prefixed with `bugsplat-hang-` (duration, detection time, app state, launch id) that can be used to correlate them with crashes from the same launch.
+
+{% hint style="info" %}
+Detection is suppressed when a debugger is attached or while the app is not active in the foreground. On iOS and tvOS this means hangs that begin while the app is in the background — including those terminated by background-task expiration — are not reported. Hang detection is also a no-op inside app extensions.
+{% endhint %}
+
+The `hangDetectionThreshold` property accepts values in seconds. Typical production values are between 1.0 and 5.0 seconds. Pick a value that comfortably exceeds any work your app may legitimately do on the main thread (image decoding, JSON parsing, etc.) to avoid false positives. Values below `0.1` are clamped to `0.1`.
+
 ### Sample Applications 🧑‍🏫
 
 `Example_Apps` includes several iOS and macOS BugSplat Test apps. Integrating BugSplat only requires the xcframework and a few lines of code.


### PR DESCRIPTION
## Summary

- Document the new `enableHangDetection` + `hangDetectionThreshold` API on both the iOS and macOS integration pages, including caveats around debugger attach, app-active state, and app extensions.
- Document the existing `postFeedback` API (mirrors the Android SDK section that already covered it).
- macOS variant additionally calls out the CLI/runloop-pumping false-positive scenario.

Pairs with [BugSplat-Git/bugsplat-apple#52](https://github.com/BugSplat-Git/bugsplat-apple/pull/52) and the shipped `postFeedback` API from #42 on that repo.

## Test plan

- [ ] Render the iOS page locally and confirm the new \"User Feedback\" and \"Hang Detection\" sections appear under Crash Reporter Customization.
- [ ] Render the macOS page and confirm the same.
- [ ] Verify Swift and Objective-C samples copy-paste cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)