### PR TITLE
docs(apple): document hang detection and add User Feedback for iOS

### DIFF
--- a/introduction/getting-started/integrations/desktop/macos.md
+++ b/introduction/getting-started/integrations/desktop/macos.md
@@ -354,6 +354,32 @@ BugSplatAttachment *screenshot = [[BugSplatAttachment alloc] initWithFilename:@"
 }];
 ```
 
+### ⏱️ Hang Detection
+
+BugSplat can detect fatal main-thread hangs and upload them on the next launch using the same pipeline as crash reports. When enabled, BugSplat watches the main thread; if it stays unresponsive for longer than the configured threshold and the app is then terminated without the main thread recovering (a launch/resume watchdog kill or user force-quit), a hang report is uploaded on the next launch. Non-fatal hangs — those where the main thread eventually resumes — are discarded automatically.
+
+Enable hang detection by setting `enableHangDetection` to `YES` **before** calling `start`. `start` must be invoked on the main thread when this property is enabled.
+
+```swift
+BugSplat.shared().enableHangDetection = true
+BugSplat.shared().hangDetectionThreshold = 2.0 // optional, defaults to 2.0 seconds
+BugSplat.shared().start()
+```
+
+```objectivec
+[[BugSplat shared] setEnableHangDetection:YES];
+[[BugSplat shared] setHangDetectionThreshold:2.0]; // optional, defaults to 2.0 seconds
+[[BugSplat shared] start];
+```
+
+Hang reports carry the exception name `App Hang (Fatal)` and include attributes prefixed with `bugsplat-hang-` (duration, detection time, app state, launch id) that can be used to correlate them with crashes from the same launch.
+
+{% hint style="info" %}
+Detection is suppressed while a debugger is attached. macOS apps have no UIApplication background state, so detection runs whenever the app is launched. Command-line tools can opt in, but be aware that any code path that blocks the main thread without pumping the runloop (for example `std::getline` on stdin) will look like a hang until the runloop runs again.
+{% endhint %}
+
+The `hangDetectionThreshold` property accepts values in seconds. Typical production values are between 1.0 and 5.0 seconds. Pick a value that comfortably exceeds any work your app may legitimately do on the main thread (image decoding, JSON parsing, etc.) to avoid false positives. Values below `0.1` are clamped to `0.1`.
+
 ### Sample Applications 🧑‍🏫
 
 `Example_Apps` includes several iOS and macOS BugSplat Test apps. Integrating BugSplat only requires the xcframework and a few lines of code.

--- a/introduction/getting-started/integrations/mobile/ios.md
+++ b/introduction/getting-started/integrations/mobile/ios.md
@@ -313,6 +313,73 @@ Bugsplat supports uploading attachments with crash reports. There's a delegate m
 
 Bitcode was introduced by Apple to allow apps sent to the App Store to be recompiled by Apple itself and apply the latest optimization. Bitcode has now been officially deprecated by Apple and should be removed or disabled. If Bitcode is enabled, the symbols generated for your app in the store will be different than the ones from your own build system. We recommend that you disable bitcode in order for BugSplat to reliably symbolicate crash reports. Disabling bitcode significantly simplifies symbols management and currently doesn't have any known downsides for iOS apps.
 
+### 💬 User Feedback
+
+In addition to crash reporting, BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title.
+
+```objectivec
+[[BugSplat shared] postFeedback:@"Login button broken"
+                    description:@"Nothing happens when I tap it"
+                       userName:@"Jane"
+                      userEmail:@"jane@example.com"
+                         appKey:@"pro-tier"
+                    attachments:nil
+                     completion:^(NSError *error) {
+    if (error) {
+        NSLog(@"Feedback failed: %@", error);
+    } else {
+        NSLog(@"Feedback submitted successfully");
+    }
+}];
+```
+
+To include file attachments such as screenshots:
+
+```objectivec
+BugSplatAttachment *screenshot = [[BugSplatAttachment alloc] initWithFilename:@"screenshot.png"
+                                                              attachmentData:imageData
+                                                                 contentType:@"image/png"];
+[[BugSplat shared] postFeedback:@"Login button broken"
+                    description:@"Nothing happens when I tap it"
+                       userName:@"Jane"
+                      userEmail:@"jane@example.com"
+                         appKey:nil
+                    attachments:@[screenshot]
+                     completion:^(NSError *error) {
+    if (error) {
+        NSLog(@"Feedback failed: %@", error);
+    } else {
+        NSLog(@"Feedback submitted successfully");
+    }
+}];
+```
+
+### ⏱️ Hang Detection
+
+BugSplat can detect fatal main-thread hangs and upload them on the next launch using the same pipeline as crash reports. When enabled, BugSplat watches the main thread; if it stays unresponsive for longer than the configured threshold and the app is then terminated without the main thread recovering (a launch/resume watchdog kill or user force-quit), a hang report is uploaded on the next launch. Non-fatal hangs — those where the main thread eventually resumes — are discarded automatically.
+
+Enable hang detection by setting `enableHangDetection` to `YES` **before** calling `start`. `start` must be invoked on the main thread when this property is enabled.
+
+```swift
+BugSplat.shared().enableHangDetection = true
+BugSplat.shared().hangDetectionThreshold = 2.0 // optional, defaults to 2.0 seconds
+BugSplat.shared().start()
+```
+
+```objectivec
+[[BugSplat shared] setEnableHangDetection:YES];
+[[BugSplat shared] setHangDetectionThreshold:2.0]; // optional, defaults to 2.0 seconds
+[[BugSplat shared] start];
+```
+
+Hang reports carry the exception name `App Hang (Fatal)` and include attributes prefixed with `bugsplat-hang-` (duration, detection time, app state, launch id) that can be used to correlate them with crashes from the same launch.
+
+{% hint style="info" %}
+Detection is suppressed while a debugger is attached or while the app is not active in the foreground. As a consequence, hangs that begin while the app is in the background (including those terminated by background-task expiration) are not reported. Hang detection is also a no-op inside app extensions.
+{% endhint %}
+
+The `hangDetectionThreshold` property accepts values in seconds. Typical production values are between 1.0 and 5.0 seconds. Pick a value that comfortably exceeds any work your app may legitimately do on the main thread (image decoding, JSON parsing, etc.) to avoid false positives. Values below `0.1` are clamped to `0.1`.
+
 ### Sample Applications 🧑‍🏫
 
 `Example_Apps` includes several iOS and macOS BugSplat Test apps. Integrating BugSplat only requires the xcframework and a few lines of code.


### PR DESCRIPTION
Replaces #154, which was based on an in-progress branch (\`docs/user-feedback-java-android\`) and conflicted with master after that work landed.

## Summary

- Adds a **Hang Detection** section to both \`introduction/getting-started/integrations/mobile/ios.md\` and \`introduction/getting-started/integrations/desktop/macos.md\`, documenting the new \`enableHangDetection\` and \`hangDetectionThreshold\` APIs on the Apple SDK.
- Adds the missing **User Feedback** section to the iOS page (it already exists on macOS) for parity.

Pairs with [BugSplat-Git/bugsplat-apple#56](https://github.com/BugSplat-Git/bugsplat-apple/pull/56).

## Test plan

- [x] Render the iOS page locally and confirm the new sections appear after Crash Reporter Customization.
- [x] Render the macOS page and confirm Hang Detection appears between User Feedback and Sample Applications.
- [x] Verify the Swift and Objective-C examples copy-paste cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)