### PR TITLE
docs(unity): document mobile hang detection (Android ANR + iOS)

### DIFF
--- a/introduction/getting-started/integrations/game-development/unity.md
+++ b/introduction/getting-started/integrations/game-development/unity.md
@@ -292,9 +292,29 @@ When you build your app for Android, be sure to set `Create symbols.zip` to `Deb
 
 <figure><img src="../../../../.gitbook/assets/image (71).png" alt=""><figcaption></figcaption></figure>
 
+#### ANR Detection
+
+When native crash reporting is enabled, the bugsplat-unity plugin also reports ANRs (Application Not Responding events). No additional configuration is required.
+
+On the next app launch, the SDK queries the OS for ANRs that occurred during the previous session, reads the system-provided thread dump, and uploads it to BugSplat. ANR reports appear alongside crashes with the **`Android.ANR`** type. The sample project's **Hang / ANR** button triggers an ANR for testing.
+
+{% hint style="info" %}
+ANR detection requires Android 11 (API level 30) or higher at runtime. On older versions it is silently disabled, while native crash reporting continues to work.
+{% endhint %}
+
 ### 🍎 iOS
 
-The bugsplat-unity plugin supports crash reporting for native C++ crashes on iOS via bugsplat-ios. To configure crash reporting for iOS, set the `UseNativeCrashReportingForIos` and `UploadDebugSymbolsForIos` properties to `true` on the BugSplatManager instance.
+The bugsplat-unity plugin supports crash reporting for native C++ crashes on iOS via bugsplat-apple. To configure crash reporting for iOS, set the `UseNativeCrashReportingForIos` and `UploadDebugSymbolsForIos` properties to `true` on the BugSplatManager instance.
+
+#### Hang Detection
+
+When native crash reporting is enabled, the bugsplat-unity plugin also detects fatal main-thread hangs. No additional configuration is required.
+
+If the main thread stays unresponsive past the detection threshold and the app is then terminated without recovering — by the OS watchdog at launch or resume, or by the user force-quitting — BugSplat uploads a hang report on the next launch. Hangs the app recovers from are not reported. Hang reports carry the exception name **`App Hang (Fatal)`**. The sample project's **Hang / ANR** button triggers a hang for testing.
+
+{% hint style="info" %}
+Hang detection is suppressed while a debugger is attached. Test it on a build run without the Xcode debugger.
+{% endhint %}
 
 ### 🧩 API
 


### PR DESCRIPTION
## Summary

Documents ANR (Android) and fatal hang detection (iOS) in the Unity integration guide, covering the features added in [bugsplat-unity#122](https://github.com/BugSplat-Git/bugsplat-unity/pull/122) (v4.1.0).

- **Android** — new `#### ANR Detection` subsection: automatic ANR reporting (`Android.ANR`) when native crash reporting is enabled, Android 11+ requirement.
- **iOS** — new `#### Hang Detection` subsection: automatic fatal main-thread hang reporting (`App Hang (Fatal)`) when native crash reporting is enabled, debugger-suppression note.
- Corrects a stale `bugsplat-ios` reference to `bugsplat-apple` in the iOS section.

Wording mirrors the existing ANR/hang sections in the `mobile/android.md` and `mobile/ios.md` guides for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)