### PR TITLE
Add Support Response section to Unreal Engine docs

### DIFF
--- a/introduction/getting-started/integrations/game-development/unreal-engine.md
+++ b/introduction/getting-started/integrations/game-development/unreal-engine.md
@@ -168,19 +168,7 @@ In addition to crash reporting, BugSplat supports collecting non-crashing user f
 
 ## Support Response 🆘
 
-BugSplat can display a custom support message to your end users immediately after a crash is submitted. Messages are configured per crash group and application key in the BugSplat web app. For a full walkthrough, see our blog post: [Bringing Custom Crash Responses to Unreal Engine](https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/).
-
-### Delivering Localized Responses
-
-To deliver localized support responses, append a `BugSplatApplicationKey` query parameter to your `DataRouterUrl`. BugSplat will use that value to look up the matching support message and include a link to it in the crash post response:
-
-```
-DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US"
-```
-
-For a dynamically chosen key — for example, one that reflects the user's system language — you'll need a [customized CrashReportClient](https://blog.bugsplat.com/customizing-the-unreal-engine-crash-report-client/) that appends the parameter at runtime before posting the crash report.
-
-Alternatively, you can set `BugSplatApplicationKey` via `SetGameData` in your game code (see [Custom Fields](#custom-fields-)), which the backend will extract from `CrashContext.runtime-xml` and store with the crash record.
+BugSplat can display a custom support message to your end users immediately after a crash is submitted. You can append a `BugSplatApplicationKey` query parameter to your `DataRouterUrl` to control which message is shown, making it possible to deliver localized responses to your players using a [customized CrashReportClient](https://blog.bugsplat.com/customizing-the-unreal-engine-crash-report-client/). For example: `DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US"`. For a full walkthrough, see [Bringing Custom Crash Responses to Unreal Engine](https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/).
 
 ## Licensee Builds 🤝
 

--- a/introduction/getting-started/integrations/game-development/unreal-engine.md
+++ b/introduction/getting-started/integrations/game-development/unreal-engine.md
@@ -168,7 +168,13 @@ In addition to crash reporting, BugSplat supports collecting non-crashing user f
 
 ## Support Response 🆘
 
-BugSplat can display a custom support message to your end users immediately after a crash is submitted. You can append a `BugSplatApplicationKey` query parameter to your `DataRouterUrl` to control which message is shown, making it possible to deliver localized responses to your players using a [customized CrashReportClient](https://blog.bugsplat.com/customizing-the-unreal-engine-crash-report-client/). For example: `DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US"`. For a full walkthrough, see [Bringing Custom Crash Responses to Unreal Engine](https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/).
+BugSplat can display a custom support message to your end users immediately after a crash is submitted. You can append a `BugSplatApplicationKey` query parameter to your `DataRouterUrl` to control which message is shown, making it possible to deliver localized responses to your players using a [customized CrashReportClient](https://blog.bugsplat.com/customizing-the-unreal-engine-crash-report-client/).
+
+```ini
+DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US"
+```
+
+For a full walkthrough, see [Bringing Custom Crash Responses to Unreal Engine](https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/).
 
 ## Licensee Builds 🤝
 

--- a/introduction/getting-started/integrations/game-development/unreal-engine.md
+++ b/introduction/getting-started/integrations/game-development/unreal-engine.md
@@ -166,6 +166,22 @@ AMyUnrealCrasherGameModeBase::AMyUnrealCrasherGameModeBase()
 
 In addition to crash reporting, BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat with the "User Feedback" type, grouped by title. For more information about how to add user feedback to your game please refer to the [BugSplat Unreal Plugin](unreal-engine/unreal-engine-plugin.md#user-feedback) documentation.
 
+## Support Response 🆘
+
+BugSplat can display a custom support message to your end users immediately after a crash is submitted. Messages are configured per crash group and application key in the BugSplat web app. For a full walkthrough, see our blog post: [Bringing Custom Crash Responses to Unreal Engine](https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/).
+
+### Delivering Localized Responses
+
+To deliver localized support responses, append a `BugSplatApplicationKey` query parameter to your `DataRouterUrl`. BugSplat will use that value to look up the matching support message and include a link to it in the crash post response:
+
+```
+DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US"
+```
+
+For a dynamically chosen key — for example, one that reflects the user's system language — you'll need a [customized CrashReportClient](https://blog.bugsplat.com/customizing-the-unreal-engine-crash-report-client/) that appends the parameter at runtime before posting the crash report.
+
+Alternatively, you can set `BugSplatApplicationKey` via `SetGameData` in your game code (see [Custom Fields](#custom-fields-)), which the backend will extract from `CrashContext.runtime-xml` and store with the crash record.
+
 ## Licensee Builds 🤝
 
 Some forks of Unreal (e.g., Oculus) are set up as a "Licensee" build. Regardless of other settings, crash reports won't be sent because of this [block of code](https://github.com/EpicGames/UnrealEngine/blob/5ccd1d8b91c944d275d04395a037636837de2c56/Engine/Source/Runtime/Core/Private/Unix/UnixPlatformCrashContext.cpp#L594-L600):

--- a/introduction/getting-started/integrations/game-development/unreal-engine.md
+++ b/introduction/getting-started/integrations/game-development/unreal-engine.md
@@ -174,6 +174,12 @@ BugSplat can display a custom support message to your end users immediately afte
 DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US"
 ```
 
+Additionally, you can speed up the time it takes for BugSplat to return a response by including a `PCallstackHash` value.
+
+```ini
+DataRouterUrl="https://{database}.bugsplat.com/post/ue4/{appName}/{appVersion}?BugSplatApplicationKey=en-US&PCallstackHash=BDC1CA7AD7CB73BC100C41E5AA322C243521BD59"
+```
+
 For a full walkthrough, see [Bringing Custom Crash Responses to Unreal Engine](https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/).
 
 ## Licensee Builds 🤝


### PR DESCRIPTION
## Summary

- Adds a new **Support Response 🆘** section to the Unreal Engine integration page
- Explains the `BugSplatApplicationKey` URL query parameter on `DataRouterUrl` as a way to deliver localized support responses through a customized CrashReportClient
- Links to the blog post walkthrough: https://blog.bugsplat.com/bringing-custom-crash-responses-to-unreal-engine/
- Also cross-references the existing Custom Fields section for the `SetGameData` approach

## Test plan

- [x] Preview renders correctly in GitBook (no broken links, code block formats properly)
- [x] Blog post link resolves
- [x] Anchor link to `#custom-fields-` works in the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)