### PR TITLE
docs: C API and BugSplat.dll dynamic library for Windows C++

### DIFF
--- a/introduction/getting-started/integrations/desktop/cplusplus/README.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/README.md
@@ -12,6 +12,18 @@ This document explains how to modify your Microsoft Visual C++ application to pr
 
 To begin, [download](https://app.bugsplat.com/browse/download_item.php?item=native) and unzip the BugSplat SDK for Microsoft Visual C++.
 
+The SDK is organized per platform (`win32`, `x64`, `ARM64`) and configuration (`Release`, `Debug`):
+
+| Folder | Contents |
+| --- | --- |
+| `BugSplat\inc` | `BugSplat.h` (C++ API) and `BugSplatC.h` (C API) |
+| `BugSplat\<platform>\<config>\bin` | Runtime files that ship next to your executable: `BugSplatMonitor.exe`, `BugSplatRc.dll`, `BugSplatWer.dll`, and `BugSplat.dll` |
+| `BugSplat\<platform>\<config>\lib\md` | Static `BugSplat.lib` built with `/MD` (dynamic CRT) |
+| `BugSplat\<platform>\<config>\lib\mt` | Static `BugSplat.lib` built with `/MT` (static CRT) |
+| `BugSplat\<platform>\<config>\lib\dll` | Import library for `BugSplat.dll` |
+
+Link exactly one `BugSplat.lib` from the `lib` subfolder that matches your link model and runtime library setting, and ship the contents of `bin` with your application (`BugSplat.dll` is only needed if you link the import library).
+
 To get a feel for the BugSplat service before enabling your application, feel free to experiment with the [MyConsoleCrasher sample application](../../../posting-a-test-crash/myconsolecrasher-c-plus-plus/), which is included as part of the software development kit and is also available on [GitHub](https://github.com/BugSplat-Git/Samples).
 
 ### Integration 🏗️
@@ -22,8 +34,8 @@ For WinUI 3 applications, BugSplat must be registered as a WER [RuntimeException
 
 Add BugSplat to your application using the following steps:
 
-1. Link with **`BugSplat.lib`**  by adding an entry to `Linker > Input > Additional Dependencies`.
-2. Add **`BugSplatMonitor.exe`**, **`BugSplatWer.dll`**, and **`BugSplatRc.dll`** to your application's installer.
+1. Link with **`BugSplat.lib`**  by adding an entry to `Linker > Input > Additional Dependencies`, and add the matching folder to `Linker > General > Additional Library Directories` — `lib\md` if your application builds with `/MD` (the Visual Studio default), or `lib\mt` if it builds with `/MT`.
+2. Add **`BugSplatMonitor.exe`**, **`BugSplatWer.dll`**, and **`BugSplatRc.dll`** (from the SDK's `bin` folder) to your application's installer.
 3. Ensure your installer runs with Administrator privileges and creates a `RuntimeExceptionHelperModules` registry key with a name containing the full path to `BugSplatWer.dll`. For more information about configuring WER see this [doc](bugsplat-for-windows-upgrade-guide.md#registry-changes).
 
 <figure><img src="../../../../../.gitbook/assets/image (85).png" alt=""><figcaption></figcaption></figure>
@@ -57,7 +69,7 @@ The SDK also ships as a dynamic library, **`BugSplat.dll`**, with a flat C API d
 
 To integrate the dynamic library, follow the steps above with these differences:
 
-1. Link with the import library **`dynamic\BugSplat.lib`** instead of the static `BugSplat.lib`, and include **`BugSplatC.h`** instead of `BugSplat.h`.
+1. Link with the import library **`lib\dll\BugSplat.lib`** instead of a static `BugSplat.lib`, and include **`BugSplatC.h`** instead of `BugSplat.h`.
 2. Ship **`BugSplat.dll`** alongside your executable, in addition to `BugSplatMonitor.exe`, `BugSplatWer.dll`, and `BugSplatRc.dll`.
 3. Initialize BugSplat with the C API:
 

--- a/introduction/getting-started/integrations/desktop/cplusplus/README.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/README.md
@@ -48,6 +48,31 @@ symbol-upload-windows.exe -b your-database -a your-app -v your-version -i your-c
 To get complete symbolicated call stacks and variable names for each crash, you should upload all **`.exe`**, **`.dll`**, and **`.pdb`** files for your product every time you build a release version of your application for distribution or internal testing.
 {% endhint %}
 
+### Dynamic Library 🔗
+
+The SDK also ships as a dynamic library, **`BugSplat.dll`**, with a flat C API declared in **`BugSplatC.h`**. The DLL exposes the same crash reporting engine as `BugSplat.lib` through `BugSplat_*` functions. Choose the dynamic library when:
+
+* You don't want your runtime library setting (`/MT` vs `/MD`) coupled to BugSplat's — only the C ABI crosses the DLL boundary, so your application's CRT choice doesn't need to match the SDK's.
+* You're calling BugSplat from another language (C#, Rust, Python, etc.) via P/Invoke or FFI.
+
+To integrate the dynamic library, follow the steps above with these differences:
+
+1. Link with the import library **`dynamic\BugSplat.lib`** instead of the static `BugSplat.lib`, and include **`BugSplatC.h`** instead of `BugSplat.h`.
+2. Ship **`BugSplat.dll`** alongside your executable, in addition to `BugSplatMonitor.exe`, `BugSplatWer.dll`, and `BugSplatRc.dll`.
+3. Initialize BugSplat with the C API:
+
+```cpp
+#include "BugSplatC.h"
+
+BugSplat_Init(BUGSPLAT_DATABASE, APPLICATION_NAME, APPLICATION_VERSION);
+BugSplat_SetUser(L"fred");
+BugSplat_SetAttribute(L"branch", L"main");
+```
+
+{% hint style="info" %}
+The C API is also available to static library consumers — define `BUGSPLAT_STATIC` before including `BugSplatC.h`. See the [API documentation](bugsplat-for-windows-api-documentation.md#c-api-bugsplatc.h) for the full list of `BugSplat_*` functions.
+{% endhint %}
+
 ### Verification ✅
 
 Test your application by forcing a crash.

--- a/introduction/getting-started/integrations/desktop/cplusplus/README.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/README.md
@@ -40,6 +40,15 @@ Add BugSplat to your application using the following steps:
 
 <figure><img src="../../../../../.gitbook/assets/image (85).png" alt=""><figcaption></figcaption></figure>
 
+{% hint style="warning" %}
+BugSplat's runtime files (`BugSplatMonitor.exe`, `BugSplatWer.dll`, and `BugSplat.dll` if you use the dynamic library) depend on the **Visual C++ 2015–2022 runtime** — `MSVCP140.dll`, `VCRUNTIME140.dll`, and `VCRUNTIME140_1.dll` on x64. These DLLs are **not part of Windows** and are missing on machines where no application has installed the redistributable. If they're absent, your application will run normally but crash reporting will fail — end users may see a "MSVCP140.dll was not found" error at crash time.
+
+This applies even if your own application doesn't need the Visual C++ runtime (for example, if it's built with `/MT`). Make sure your installer either:
+
+* chains the [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) installer that **matches the architecture of the BugSplat files you ship** (`vc_redist.x64.exe`, `vc_redist.x86.exe`, or `vc_redist.arm64.exe`), or
+* copies `msvcp140.dll` and `vcruntime140.dll` (plus `vcruntime140_1.dll` on x64) from the redistributable into your application folder alongside the BugSplat runtime files.
+{% endhint %}
+
 4. Include **`BugSplat.h`** in your application's source.
 5. Create an instance of `BugSplat` following the example in [MyConsoleCrasher](../../../posting-a-test-crash/myconsolecrasher-c-plus-plus/). The BugSplat constructor requires three parameters: `database`, `application`, and `version`. A new BugSplat database can be created on the [Database](https://app.bugsplat.com/v2/database) page. Choose values for application name and version to match your product release. These same values are typically used when uploading symbol files for your application. Learn more about symbol uploads at [symbol-upload](../../../../../education/faq/how-to-upload-symbol-files-with-symbol-upload.md).
 

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -161,6 +161,18 @@ void SetCrashCompletionBehavior(BugSplatCrashCompletion behavior);
 
 * `behavior` - one of the `BugSplatCrashCompletion` values above (default `Exit`)
 
+#### SetCrashType
+
+```cpp
+void SetCrashType(int crashTypeId);
+```
+
+**Description:** Overrides the BugSplat crash type id stamped on uploaded crashes. By default native crashes are uploaded as `Native` (id `1`). Set this when a higher-level integration needs the server to process the crash differently — for example, a Unity IL2CPP integration sets `15` (`UnityNative`: "a native crash with an additional file containing the managed call stack"), which is the crash type the BugSplat backend uses to apply `LineNumberMappings.json` and symbolicate managed (C#) frames.
+
+**Parameters:**
+
+* `crashTypeId` - the BugSplat crash type id (default `1` = Native; `15` = UnityNative)
+
 ***
 
 ### Crash Detection & Reporting
@@ -459,6 +471,7 @@ The remaining functions forward to the equivalent `BugSplat` class methods docum
 | `BugSplat_SetQuietMode`             | `SetQuietMode`             |
 | `BugSplat_SetHangDetectionTimeout`  | `SetHangDetectionTimeout`  |
 | `BugSplat_SetCrashCompletionBehavior` | `SetCrashCompletionBehavior` |
+| `BugSplat_SetCrashType`               | `SetCrashType`               |
 | `BugSplat_PostAllCrashesAsync`      | `PostAllCrashesAsync`      |
 | `BugSplat_CreateXmlReport`          | `CreateXmlReport`          |
 | `BugSplat_CreateAsanReport`         | `CreateAsanReport`         |

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -143,17 +143,23 @@ void SetHangDetectionTimeout(int ms);
 
 * `ms` - Timeout in milliseconds (default: 5000). Use 0 to disable hang detection.
 
-#### SetTerminateAfterCrash
+#### SetCrashCompletionBehavior
 
 ```cpp
-void SetTerminateAfterCrash(bool terminate);
+enum class BugSplatCrashCompletion { Exit = 0, Terminate = 1, ContinueSearch = 2 };
+
+void SetCrashCompletionBehavior(BugSplatCrashCompletion behavior);
 ```
 
-**Description:** Controls how the process ends after a crash report is created and uploaded. When `false` (the default), the handler calls `exit()`, which runs full C-runtime shutdown. When `true`, it calls `TerminateProcess` instead — a hard termination that avoids CRT-shutdown hangs in complex hosts (for example, a Unity standalone player whose process can hang on `exit()` after the report is sent). The dump is created and uploaded before either path, so reporting is unaffected.
+**Description:** Controls what the crash handler does after the crash report has been created and uploaded. The dump is captured and sent before any of these paths, so reporting is unaffected by the choice:
+
+* `Exit` (default) - calls `exit()`, which runs full C-runtime shutdown.
+* `Terminate` - calls `TerminateProcess`, a hard termination that avoids CRT-shutdown hangs in complex hosts (for example, a Unity standalone player whose process can hang on `exit()` after the report is sent).
+* `ContinueSearch` - returns `EXCEPTION_CONTINUE_SEARCH` from the unhandled-exception filter, handing control to the operating system's default unhandled-exception handling (Windows Error Reporting, or an attached debugger) instead of ending the process itself.
 
 **Parameters:**
 
-* `terminate` - `true` to hard-terminate after a crash, `false` (default) to `exit()`
+* `behavior` - one of the `BugSplatCrashCompletion` values above (default `Exit`)
 
 ***
 
@@ -452,7 +458,7 @@ The remaining functions forward to the equivalent `BugSplat` class methods docum
 | `BugSplat_RemoveAttachment`         | `RemoveAttachment`         |
 | `BugSplat_SetQuietMode`             | `SetQuietMode`             |
 | `BugSplat_SetHangDetectionTimeout`  | `SetHangDetectionTimeout`  |
-| `BugSplat_SetTerminateAfterCrash`   | `SetTerminateAfterCrash`   |
+| `BugSplat_SetCrashCompletionBehavior` | `SetCrashCompletionBehavior` |
 | `BugSplat_PostAllCrashesAsync`      | `PostAllCrashesAsync`      |
 | `BugSplat_CreateXmlReport`          | `CreateXmlReport`          |
 | `BugSplat_CreateAsanReport`         | `CreateAsanReport`         |

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -143,6 +143,18 @@ void SetHangDetectionTimeout(int ms);
 
 * `ms` - Timeout in milliseconds (default: 5000). Use 0 to disable hang detection.
 
+#### SetTerminateAfterCrash
+
+```cpp
+void SetTerminateAfterCrash(bool terminate);
+```
+
+**Description:** Controls how the process ends after a crash report is created and uploaded. When `false` (the default), the handler calls `exit()`, which runs full C-runtime shutdown. When `true`, it calls `TerminateProcess` instead — a hard termination that avoids CRT-shutdown hangs in complex hosts (for example, a Unity standalone player whose process can hang on `exit()` after the report is sent). The dump is created and uploaded before either path, so reporting is unaffected.
+
+**Parameters:**
+
+* `terminate` - `true` to hard-terminate after a crash, `false` (default) to `exit()`
+
 ***
 
 ### Crash Detection & Reporting
@@ -440,6 +452,7 @@ The remaining functions forward to the equivalent `BugSplat` class methods docum
 | `BugSplat_RemoveAttachment`         | `RemoveAttachment`         |
 | `BugSplat_SetQuietMode`             | `SetQuietMode`             |
 | `BugSplat_SetHangDetectionTimeout`  | `SetHangDetectionTimeout`  |
+| `BugSplat_SetTerminateAfterCrash`   | `SetTerminateAfterCrash`   |
 | `BugSplat_PostAllCrashesAsync`      | `PostAllCrashesAsync`      |
 | `BugSplat_CreateXmlReport`          | `CreateXmlReport`          |
 | `BugSplat_CreateAsanReport`         | `CreateAsanReport`         |

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -441,6 +441,29 @@ The remaining functions forward to the equivalent `BugSplat` class methods docum
 | `BugSplat_SetQuietMode`             | `SetQuietMode`             |
 | `BugSplat_SetHangDetectionTimeout`  | `SetHangDetectionTimeout`  |
 | `BugSplat_PostAllCrashesAsync`      | `PostAllCrashesAsync`      |
+| `BugSplat_CreateXmlReport`          | `CreateXmlReport`          |
+
+#### BugSplat\_PostFeedback
+
+```c
+int BugSplat_PostFeedback(const wchar_t* title,
+                          const wchar_t* description,
+                          const wchar_t* const* attachments,
+                          int attachmentCount);
+```
+
+**Description:** Posts non-crashing user feedback such as a bug report or feature request. The title is used as the stack key for grouping feedback in the dashboard.
+
+**Parameters:**
+
+* `title` - Feedback title (also the grouping key)
+* `description` - Optional description; may be `NULL` (treated as empty)
+* `attachments` - Optional array of file paths, or `NULL` for none. These are included only in this feedback upload and do not affect attachments added via `BugSplat_AddAttachment`
+* `attachmentCount` - Number of entries in `attachments` (0 if none)
+
+**Returns:** `1` on success, `0` on failure.
+
+**Note:** The C++ `BugSplat::PostFeedback` takes a `std::vector`, which cannot cross the DLL boundary. The C entry point takes an `(array, count)` pair instead so the C ABI stays free of STL types and remains compatible with `/MT` and non-C++ consumers.
 
 #### C API Example
 

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -442,6 +442,10 @@ The remaining functions forward to the equivalent `BugSplat` class methods docum
 | `BugSplat_SetHangDetectionTimeout`  | `SetHangDetectionTimeout`  |
 | `BugSplat_PostAllCrashesAsync`      | `PostAllCrashesAsync`      |
 | `BugSplat_CreateXmlReport`          | `CreateXmlReport`          |
+| `BugSplat_CreateAsanReport`         | `CreateAsanReport`         |
+| `BugSplat_SetMiniDumpType`          | `SetMiniDumpType`          |
+
+`BugSplat_SetMiniDumpType` takes the Windows `MINIDUMP_TYPE` flags as an `int`. `BugSplat_CreateAsanReport` takes a `const char*` (ASan reports are ASCII/UTF-8 text).
 
 #### BugSplat\_PostFeedback
 
@@ -464,6 +468,19 @@ int BugSplat_PostFeedback(const wchar_t* title,
 **Returns:** `1` on success, `0` on failure.
 
 **Note:** The C++ `BugSplat::PostFeedback` takes a `std::vector`, which cannot cross the DLL boundary. The C entry point takes an `(array, count)` pair instead so the C ABI stays free of STL types and remains compatible with `/MT` and non-C++ consumers.
+
+#### BugSplat\_GenerateDump
+
+```c
+void BugSplat_GenerateDump(void* exceptionPointers, int dumpType);
+```
+
+**Description:** Generates a crash report from caller-supplied exception information without terminating the process. Most applications do not need this — the exception filter installed by `BugSplat_Init` already captures unhandled crashes automatically. Use it only when you run your own exception handler and want to report a specific exception.
+
+**Parameters:**
+
+* `exceptionPointers` - An `EXCEPTION_POINTERS*` as provided by the OS inside an SEH `__except` filter (`GetExceptionInformation()`) or an unhandled-exception-filter callback. It is passed as `void*` so the header carries no `<windows.h>` dependency; it is not a value you construct.
+* `dumpType` - A combination of Windows `MINIDUMP_TYPE` flags, or a negative value to use the SDK default.
 
 #### C API Example
 

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -431,8 +431,8 @@ In addition to the `BugSplat` C++ class, the SDK exposes a flat C API declared i
 
 **Linkage:**
 
-* **Dynamic:** link the import library `dynamic\BugSplat.lib` and ship `BugSplat.dll` with your application. This is the default when including `BugSplatC.h` with no extra defines.
-* **Static:** the C API is also compiled into the static `BugSplat.lib` — define `BUGSPLAT_STATIC` before including `BugSplatC.h`.
+* **Dynamic:** link the import library `lib\dll\BugSplat.lib` and ship `BugSplat.dll` with your application. This is the default when including `BugSplatC.h` with no extra defines.
+* **Static:** the C API is also compiled into both static flavors of `BugSplat.lib` (`lib\md` for `/MD` builds, `lib\mt` for `/MT` builds) — define `BUGSPLAT_STATIC` before including `BugSplatC.h`.
 
 All strings are null-terminated UTF-16 (`wchar_t*`). Boolean parameters and return values use `int` (`0`/`1`) for ABI stability.
 

--- a/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
+++ b/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation.md
@@ -395,6 +395,73 @@ inline void SetPerThreadCRTExceptionBehavior();
 
 ***
 
+### C API (BugSplatC.h)
+
+In addition to the `BugSplat` C++ class, the SDK exposes a flat C API declared in **`BugSplatC.h`**. The C API manages a single process-wide `BugSplat` instance and is the interface exported by the dynamic library, **`BugSplat.dll`**. Because only the C ABI crosses the DLL boundary, consumers of `BugSplat.dll` do not need to match the SDK's runtime library setting (`/MT` vs `/MD`), and any language with C FFI support (C#, Rust, Python, etc.) can call these functions directly.
+
+**Linkage:**
+
+* **Dynamic:** link the import library `dynamic\BugSplat.lib` and ship `BugSplat.dll` with your application. This is the default when including `BugSplatC.h` with no extra defines.
+* **Static:** the C API is also compiled into the static `BugSplat.lib` — define `BUGSPLAT_STATIC` before including `BugSplatC.h`.
+
+All strings are null-terminated UTF-16 (`wchar_t*`). Boolean parameters and return values use `int` (`0`/`1`) for ABI stability.
+
+#### BugSplat\_Init
+
+```c
+int BugSplat_Init(const wchar_t* database, const wchar_t* appName, const wchar_t* appVersion);
+```
+
+**Description:** Initializes crash reporting and installs the unhandled exception filter. Call once, early in your application's lifetime.
+
+**Returns:** `1` on success, `0` if already initialized or if any argument is null.
+
+#### BugSplat\_IsInitialized
+
+```c
+int BugSplat_IsInitialized(void);
+```
+
+**Description:** Returns `1` if `BugSplat_Init` has been called successfully, `0` otherwise.
+
+#### Forwarding Functions
+
+The remaining functions forward to the equivalent `BugSplat` class methods documented above:
+
+| C function                          | Class method               |
+| ----------------------------------- | -------------------------- |
+| `BugSplat_SetKey`                   | `SetKey`                   |
+| `BugSplat_SetUser`                  | `SetUser`                  |
+| `BugSplat_SetEmail`                 | `SetEmail`                 |
+| `BugSplat_SetUserDescription`       | `SetUserDescription`       |
+| `BugSplat_SetNotes`                 | `SetNotes`                 |
+| `BugSplat_SetAttribute`             | `SetAttribute`             |
+| `BugSplat_AddAttachment`            | `AddAttachment`            |
+| `BugSplat_RemoveAttachment`         | `RemoveAttachment`         |
+| `BugSplat_SetQuietMode`             | `SetQuietMode`             |
+| `BugSplat_SetHangDetectionTimeout`  | `SetHangDetectionTimeout`  |
+| `BugSplat_PostAllCrashesAsync`      | `PostAllCrashesAsync`      |
+
+#### C API Example
+
+```c
+#include "BugSplatC.h"
+
+int main() {
+    BugSplat_Init(L"MyDatabase", L"MyApp", L"1.0.0");
+    BugSplat_SetUser(L"john.doe");
+    BugSplat_SetEmail(L"john.doe@example.com");
+    BugSplat_SetQuietMode(1);
+    BugSplat_PostAllCrashesAsync();
+
+    // Your application code here...
+
+    return 0;
+}
+```
+
+***
+
 ### Usage Examples
 
 #### Basic Initialization


### PR DESCRIPTION
## Summary

Documents the new flat C API (`BugSplatC.h`), the dynamic link model (`BugSplat.dll`), the `/MT` static flavor ([bugsplat-windows#156](https://github.com/BugSplat-Git/bugsplat-windows/issues/156)), and the restructured SDK layout — all added in [bugsplat-windows#155](https://github.com/BugSplat-Git/bugsplat-windows/pull/155).

### Changes

**[BugSplat for Windows (C++)](https://docs.bugsplat.com/introduction/getting-started/integrations/desktop/cplusplus)**:
- New **SDK layout** table under Getting Started: runtime files in `bin\`, static libraries in `lib\md` (`/MD`) and `lib\mt` (`/MT`), and the `BugSplat.dll` import library in `lib\dll` — link exactly one `lib\` flavor, ship the contents of `bin\`
- Integration steps updated: pick `lib\md` or `lib\mt` to match your runtime library setting; installer files come from `bin\`
- New **installer warning**: BugSplat's runtime files require the Visual C++ 2015-2022 runtime, which is *not* part of Windows - installers must chain the architecture-matched VC++ Redistributable or ship the runtime DLLs app-locally, even when the customer's own app doesn't need them (e.g. `/MT` builds). Prompted by a field report of `BsSndRpt.exe` failing with a missing `MSVCP140.dll`.
- New **Dynamic Library** section:
  - When to choose `BugSplat.dll` over a static `BugSplat.lib`: CRT independence (`/MT` vs `/MD` no longer needs to match the SDK), and foreign-language bindings via P/Invoke or FFI (e.g. bugsplat-unity)
  - Linking against the `lib\dll\BugSplat.lib` import library and shipping `BugSplat.dll`
  - C API initialization example, plus a note that static consumers can use the C API by defining `BUGSPLAT_STATIC`

**[BugSplat Native API Documentation](https://docs.bugsplat.com/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation)** — new **C API (BugSplatC.h)** section:
- Linkage notes (dynamic vs the two static flavors), string/bool ABI conventions
- `BugSplat_Init` / `BugSplat_IsInitialized` reference
- Mapping table for the forwarding functions → existing class method docs
- Usage example

## ⚠️ Merge timing

Hold until [bugsplat-windows#155](https://github.com/BugSplat-Git/bugsplat-windows/pull/155) ships in a release built from the updated `BugSplatNativeFiles.txt` (new `bin\` + `lib\{md,mt,dll}` layout, `BugSplatC.h` included) — otherwise the docs describe a zip layout customers can't download yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
