### PR TITLE
docs: fix Development docs — 34 pages (34 issues)

### DIFF
--- a/introduction/development/commenting.md
+++ b/introduction/development/commenting.md
@@ -4,7 +4,7 @@ BugSplat allows users to leave comments and have discussions about crashes and s
 
 ### Leaving Comments
 
-Using the **Activity** module found at the bottom of the [Crashes](using-the-app.md#crashes) and [Stack Key](using-the-app.md#stack-key) pages allows users to comment and discuss issues pertaining to the defect.  
+Using the **Activity** module found at the bottom of the [Crash](using-the-app.md#crash) and [Stack Key](using-the-app.md#stack-key) pages allows users to comment and discuss issues pertaining to the defect.  
 
 This can be a useful tool for making personal notes or for having a larger discussion with team members. 
 

--- a/introduction/development/grouping-crashes.md
+++ b/introduction/development/grouping-crashes.md
@@ -33,7 +33,7 @@ Auto-group rules are processed in a specific, consistent order that cannot be ch
 * At this point, neither **group-by** nor **group-after** rules matched any stack frames. The rules engine will apply the **ignore** rules starting with the top stack frame, skipping over any frames that match the **ignore** rules until it finds the first frame that isn't to be ignored. The resulting frame is used for grouping.
 
 {% hint style="info" %}
-When you specify a new Auto-Group rule, it will be applied to newly processed and reprocessed crashes only. To apply new rules, you can reprocess up to 50 reports at a time via the [Batch Reprocess](../../education/how-tos/batch-reprocess-crashes.md) button on the Crashes page. If you'd like to reprocess more than 50 crashes at a time, please contact [Support](mailto:support@bugsplat.com).
+When you specify a new Auto-Group rule, it will be applied to newly processed and reprocessed crashes only. To apply new rules, you can reprocess up to 50 reports at a time via the [Reprocess](../../education/how-tos/batch-reprocess-crashes.md) button on the Crashes page. If you'd like to reprocess more than 50 crashes at a time, please contact [Support](mailto:support@bugsplat.com).
 {% endhint %}
 
 ### Options
@@ -46,7 +46,7 @@ With all settings enabled, groups would be created by a match on the entire stri
 
 ### Crashes Page
 
-The [**Crashes**](https://app.bugsplat.com/v2/crashes) page displays a list of reports and their associated group under the **Stack Key** column. We've added a rule that effectively skips `KERNELBASE!RaiseException` and the reports are now grouped by the next frame in the stack `MyConsoleCrasher!_CxxThrowException(75)`. To see the report's stack trace, click the value in the **ID** column.
+The [**Crashes**](https://app.bugsplat.com/v2/crashes) page displays a list of reports and their associated group under the **Group** column. We've added a rule that effectively skips `KERNELBASE!RaiseException` and the reports are now grouped by the next frame in the stack `MyConsoleCrasher!_CxxThrowException(75)`. To see the report's stack trace, click the value in the **ID** column.
 
 <figure><img src="../../.gitbook/assets/image (1) (2).png" alt=""><figcaption><p>Crash Page</p></figcaption></figure>
 

--- a/introduction/development/integrating-with-tools/issue-trackers/automatic-issue-creation.md
+++ b/introduction/development/integrating-with-tools/issue-trackers/automatic-issue-creation.md
@@ -10,7 +10,7 @@ BugSplat provides the capability to auto-create issues in third-party issue trac
 
 To set up the feature, follow these steps:
 
-1. Navigate to the [Defect Tracker](https://app.bugsplat.com/v2/database/integrations) tab of the Database settings page
+1. Navigate to the [Defect Trackers](https://app.bugsplat.com/v2/database/integrations) tab of the Database settings page
 2. Follow the instructions to configure your [Defect Tracker](../#issue-trackers) if you haven't already
 3. Enable the **New Crashes** or **New Groups** setting. Consider setting the **Group Threshold** value to ensure that new groups have multiple crashes before an issue is pushed to your Defect Tracker.
 4. Save your settings.
@@ -22,7 +22,7 @@ Once these steps are completed, BugSplat will automatically create issues in you
 There are two primary options for auto-creating defects:
 
 1. **Creating a new linked issue with every new crash**: This option will generate a new issue in your linked third-party tracker for each new crash recorded in BugSplat.
-2. **Creating a new linked issue for every new type of crash group:** This option generates a new issue for each unique type of crash group that is recorded. You can also set a threshold for the number of crashes in a group that are needed before an automatic issue is created. By setting this `Group Threshold` value to  `0`, an issue will be created for every new crash group.
+2. **Creating a new linked issue for every new type of crash group:** This option generates a new issue for each unique type of crash group that is recorded. You can also set a threshold for the number of crashes in a group that are needed before an automatic issue is created. By setting this `Group Threshold` value to `1`, an issue will be created for every new crash group.
 
 #### Feedback and Feature Requests
 

--- a/introduction/development/integrating-with-tools/issue-trackers/azure-devops.md
+++ b/introduction/development/integrating-with-tools/issue-trackers/azure-devops.md
@@ -5,11 +5,11 @@ Visual Studio Team Services (Azure DevOps) integration with BugSplat allows your
 ### Integrating Azure DevOps with BugSplat
 
 1. Login to your BugSplat account.
-2. Click the Gear icon (⚙️) in the top right of the page and navigate to the Database Settings page, and under **Database > Integrations >** **Defect Tracker**, select **Azure DevOps** from the options shown.
+2. Click the Gear icon (⚙️) in the top right of the page and navigate to the Database Settings page, and under **Database > Integrations >** **Defect Trackers**, select **Azure DevOps** from the options shown.
 3. Enter your **Azure DevOps URL** and **Personal Access Token** into the appropriate fields.
-4. Click **Apply**.
+4. Click **Update**.
 5. If the connection is successful, you can select your desired project from the **Project** dropdown list.
-6. Click **Apply**.
+6. Click **Update**.
 
 ### Creating an issue in Azure DevOps from a BugSplat crash report
 

--- a/introduction/development/integrating-with-tools/issue-trackers/favro.md
+++ b/introduction/development/integrating-with-tools/issue-trackers/favro.md
@@ -9,8 +9,8 @@ BugSplat allows your team to create cards in [Favro](https://favro.com/) with a 
 #### Integrating Favro and BugSplat
 
 1. Create an API token in Favro via **My Profile > API Tokens > Create New Token**
-2. Navigate to the **⚙️ > Integrations > Defect Tracker** page in BugSplat
-3. Select **Favro** and click the **Integrate** button
+2. Navigate to the **⚙️ > Integrations > Defect Trackers** page in BugSplat
+3. Select **Favro** and click the **Connect** button
 4. Enter your **Email** and **Token** and click **Update**
 5. You should now see a list of organizations. Choose the correct organization and click **Update**
 6. You should now see a list of widgets. Choose a widget and click **Update**

--- a/introduction/development/integrating-with-tools/issue-trackers/github-issues.md
+++ b/introduction/development/integrating-with-tools/issue-trackers/github-issues.md
@@ -6,10 +6,10 @@ BugSplat's GitHub Issues integration allows your team to create defects from cra
 
 1. Generate a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT) in GitHub. You may use a [classic PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic) or a [fine-grained PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens), ensuring you set the correct **Resource Owner**, select the correct **Repository**, and add **Issues Read/Write** permissions.
 2. [Login](https://app.bugsplat.com/cognito/login) to your BugSplat account.
-3. Click the Gear icon (⚙️) in the top right of the page and navigate to the [Database Settings](https://app.bugsplat.com/v2/database/integrations) page and under **Database > Integrations >** **Defect Tracker > GitHub Issues** from the options shown.
-4. Enter your GitHub **Username**, **API Token,** and **Repo Owner** into the appropriate boxes and click **Apply**.
+3. Click the Gear icon (⚙️) in the top right of the page and navigate to the [Database Settings](https://app.bugsplat.com/v2/database/integrations) page and under **Database > Integrations >** **Defect Trackers > GitHub** from the options shown.
+4. Enter your GitHub **Username**, **API Token,** and **Repo Owner** into the appropriate boxes and click **Update**.
 5. Select your desired project.
-6. Click **Apply** once more to complete the integration.
+6. Click **Update** once more to complete the integration.
 
 ### Creating a defect in GitHub Issues from a BugSplat crash report
 

--- a/introduction/development/integrating-with-tools/issue-trackers/jira.md
+++ b/introduction/development/integrating-with-tools/issue-trackers/jira.md
@@ -6,11 +6,11 @@ BugSplat's Jira integration allows your team to create defects with a few clicks
 
 1. Login to your account.
 2. Click the Gear icon (⚙️) at the top right of the page and navigate to the [Database Settings](https://app.bugsplat.com/v2/database/integrations) page, and under **Database > Integrations >** **Defect Tracker**, select **Jira** from the options shown.
-3. Enter your **Username**, **Token**, **URL**, and **Issue Type** into the appropriate boxes. For Jira Cloud, use an [API Token](https://id.atlassian.com/manage-profile/security/api-tokens) in the **Token** field. For self-hosted Jira Server use your account's password for the **Token** field.
-4. Click **Apply**.
+3. Enter your **Username**, **Token**, and **URL** into the appropriate boxes. For Jira Cloud, use an [API Token](https://id.atlassian.com/manage-profile/security/api-tokens) in the **Token** field. For self-hosted Jira Server use your account's password for the **Token** field.
+4. Click **Update**.
 5. Once a connection to Jira has been established, you can select one of your projects from the project dropdown list.
-6. After selecting your desired project, click **Apply** again.
-7. Add additional data in any of the other fields.
+6. After selecting your desired project, click **Update** again.
+7. Add additional data in any of the other fields, including the optional **Issue Type** field.
 
 {% hint style="info" %}
 The optional **Assignee ID** field requires the Atlassian user ID when using Jira Cloud. Jira Server doesn't support user IDs, so use the user name.

--- a/introduction/development/integrating-with-tools/issue-trackers/youtrack.md
+++ b/introduction/development/integrating-with-tools/issue-trackers/youtrack.md
@@ -6,14 +6,14 @@ YouTrack integration with BugSplat crash reports allows your team to create defe
 
 1. [Login](https://app.bugsplat.com/cognito/login) to your account.
 2. Click the Gear icon (⚙️) in the top right of the page and navigate to the Database Settings page, and under **Database > Integrations >** **Defect Tracker**, select **YouTrack** from the options shown.
-3. Enter your **Username**, YouTrack **API Token**, YouTrack **URL**, and any additional options, and click **Apply**.
+3. Enter your **Username**, YouTrack **API Token**, YouTrack **URL**, and any additional options.
 
 {% hint style="info" %}
 You can find **Username**, **API Token**, and **URL** on the YouTrack Hub Integration page. [Click to learn more](https://www.jetbrains.com/help/youtrack/incloud/Manage-Permanent-Token.html).
 {% endhint %}
 
 4. Select your desired **Project**.
-5. Click **Apply**.
+5. Click **Update**.
 
 ### Creating a defect in YouTrack from a BugSplat crash report
 

--- a/introduction/development/integrating-with-tools/messanger-apps/email.md
+++ b/introduction/development/integrating-with-tools/messanger-apps/email.md
@@ -7,6 +7,6 @@ These alerts let you stay on top of your crashes and can serve as an early warni
 #### Integrating Email Alerts with BugSplat <a href="#integrating-email-alerts-with-bugsplat-docs" id="integrating-email-alerts-with-bugsplat-docs"></a>
 
 1. Login to your [account](https://app.bugsplat.com/cognito/login).
-2. Go to the [Notifications](https://app.bugsplat.com/v2/database/integrations#notifications) page and hit the button under **Email Alerts**
-3. To receive emails when your database's crash rate exceeds a certain level, fill in the **Email** and **Crashes (per minute)** fields under **Crash Rate Alerts** and click **Update**.
+2. Go to the [Notifications](https://app.bugsplat.com/v2/database/integrations#notifications) page.
+3. To receive emails when your database's crash rate exceeds a certain level, fill in the **Email** and **Reports (per minute)** fields under **Crash Rate Alerts** and click **Update**.
 4. To receive hourly summaries of your database's crash activity, fill in the **Email** field under the **Hourly Report Digest Email** section and click **Update**.

--- a/introduction/development/integrating-with-tools/messanger-apps/microsoft-teams.md
+++ b/introduction/development/integrating-with-tools/messanger-apps/microsoft-teams.md
@@ -12,7 +12,7 @@ Teams Webhook Walkthrough
 2. Login to [BugSplat](https://app.bugsplat.com/cognito/login) and navigate to the [Notifications](https://app.bugsplat.com/v2/database/integrations#notifications) page.
 3. Select the Database for which you'd like to configure alerts
 4. Under the **Teams** section, enter the webhook URL for your channel and click **Update**.
-5. Use the toggle buttons to set your notification preferences. You can be notified for each new report or unique report group.
+5. Use the toggle buttons to set your notification preferences: **New Report Notifications**, **New Group Notifications**, and **Regression Alerts**.
 6. Use the **Fields** dropdown to select the fields you want to include in your notifications.
 
 <figure><img src="../../../../.gitbook/assets/teams.gif" alt=""><figcaption><p>Configuring BugSplat's Teams Integration</p></figcaption></figure>

--- a/introduction/development/integrating-with-tools/messanger-apps/slack.md
+++ b/introduction/development/integrating-with-tools/messanger-apps/slack.md
@@ -23,7 +23,7 @@ Very best,
 3. Under the **Slack** section, click the **Add to Slack** button.
 4. You’ll be prompted to confirm your identity and choose which channel you would like the notifications posted to.
 5. Select **Authorize**.
-6. Use the toggle buttons to set your notification preferences. You can choose to be notified for each new report or each new unique report group.
+6. Use the toggle buttons to set your notification preferences: **New Report Notifications**, **New Group Notifications**, and **Regression Alerts**.
 7. Use the **Fields** dropdown to select the fields you'd like to include in your notifications.
 
 <figure><img src="../../../../.gitbook/assets/slack.gif" alt=""><figcaption><p>Configuring BugSplat's Slack Integration</p></figcaption></figure>

--- a/introduction/development/integrating-with-tools/messanger-apps/webhook.md
+++ b/introduction/development/integrating-with-tools/messanger-apps/webhook.md
@@ -42,3 +42,5 @@ Notification payload for new BugSplat report or new BugSplat group. &#x20;
 | platform         | string       | Human-readable platform name (e.g., "Windows", "macOS", "Crashpad/Breakpad", "Unity")            |
 | crashFileUrl     | string       | Presigned URL to download the crash file. URL expires after a limited time.                      |
 | attributes       | object       | Key-value pairs of custom attributes submitted with the crash report                             |
+| crashTime        | datetime     | Timestamp of when the crash occurred                                                             |
+| userDescription  | string       | End-user's description of the crash, if provided                                                 |

--- a/introduction/development/searching/search.md
+++ b/introduction/development/searching/search.md
@@ -1,6 +1,6 @@
 # Filtering
 
-To use the filtering tool first click on the button labeled 🔍 **Search** which can be found on the Crash, Summary, and Key Crash pages.
+To use the filtering tool first click on the button labeled **Add filter** which can be found on the Crashes, Summary, and Crash Group pages.
 
 Next, select a column to filter in the Search dropdown. After picking a column, select the desired search criteria and enter a value and click **Submit**. Repeat this process until you've found exactly what you're looking for.
 
@@ -14,8 +14,8 @@ BugSplat's data is grouped into various columns. Each column can hold 1 of 4 dat
 
 | **Type** | **Options**                                                                                                |
 | -------- | ---------------------------------------------------------------------------------------------------------- |
-| Text     | <p></p><p>equal to, not equal to, contains, does not contain, empty, not empty, starts with, ends with</p> |
-| Number   | equal to, not equal to, greater than, less than, empty, not empty                                          |
+| Text     | <p></p><p>equal to, not equal to, contains, does not contain, is in, is not in, empty, not empty, starts with, ends with</p> |
+| Number   | equal to, not equal to, greater than, less than, is in, is not in, empty, not empty                                          |
 | Date     | on or before, on or after                                                                                  |
 
 ### Sharing and Exporting Searches

--- a/introduction/development/using-the-app.md
+++ b/introduction/development/using-the-app.md
@@ -48,15 +48,11 @@ Finally, if a specific crash seems important and worthy of further investigation
 
 The **Crash** page allows users to get information critical for understanding and fixing the defect which originally caused the issue.
 
-### User Details
+### Report Details
 
-The **User Details** component contains information about the user who experienced a crash. The User Details table will display who crashed, where they crashed (IP address), and the description provided by the user in the crash dialog. This information is sometimes [obfuscated to protect users](../production/security-privacy-and-compliance/gdpr.md) — like it is in the image below.
+The **Report Details** panel contains information about the crash and the user who experienced it. It displays who crashed, where they crashed (IP address), and the description provided by the user in the crash dialog, as well as details such as the crashing function, line number where the crash occurred, information regarding what type of crash took place, when the crash happened, and what OS and SDK the crashing application was running on. This information is sometimes [obfuscated to protect users](../production/security-privacy-and-compliance/gdpr.md) — like it is in the image below.
 
 ![](<../../.gitbook/assets/screen-shot-2021-07-16-at-3.08.42-pm (1) (1).png>)
-
-### Crash Details
-
-The **Crash Details** component summarizes the details of a specific crash. The Crash Details component contains information such as the crashing function, line number where the crash occurred, information regarding what type of crash took place, when the crash happened, what OS and SDK the crashing application was running on, and more.
 
 ![](../../.gitbook/assets/crash-details-modal.png)
 
@@ -68,15 +64,15 @@ The **Method** column contains a list of functions in the stack trace of the thr
 
 Clicking the **>** (greater than symbol) in the left-most column will expand the **Row Details** view.
 
-The **Row Details** view will display the **Grouping Rules** and **Create Group** buttons that will allow you to [modify the way your reports are grouped](grouping-crashes.md). Grouping at a different level of the call stack is called [subkeying](../../education/bugsplat-terminology.md#subkey) and is useful in cases such as a crash that occurs in a 3rd party library, or when additional stack frames are added by a crash reporter.
+The **Row Details** view will display the **Group Rules**, **Ignore Function**, and **Ignore File** buttons that will allow you to [modify the way your reports are grouped](grouping-crashes.md). Grouping at a different level of the call stack is called [subkeying](../../education/bugsplat-terminology.md#subkey) and is useful in cases such as a crash that occurs in a 3rd party library, or when additional stack frames are added by a crash reporter.
 
-Additionally, for [Windows Native](../getting-started/integrations/desktop/cplusplus/) crashes the **Row Details** view will show a table of [Local Variables and Function Arguments.](https://www.bugsplat.com/blog/development/local-variables-function-arguments/)
+Additionally, for [Windows Native](../getting-started/integrations/desktop/cplusplus/) crashes the **Row Details** view will show a table of [Local Variables and Function Arguments.](https://blog.bugsplat.com/local-variables-function-arguments/)
 
 The Crash page includes valuable information like crash time, environment, corresponding function name and line number, containing [stack key](../../education/bugsplat-terminology.md#stack-key), and much more.
 
 ### Additional Information
 
-All data covered to this point on the Crash page are found under the **Crash Overview** tab. To access additional information about crashes like **Other Threads**, **Registers**, **Modules**, **Debugger Output**, and **Attachments** — use the tabs found above the **User Details** module.
+All data covered to this point on the Crash page are found under the **Overview** tab. To access additional information about crashes like **Other Threads**, **Registers**, **Modules**, **Attributes**, **Debugger Output**, and **Attachments** — use the tabs found above the **Report Details** module.
 
 ![](<../../.gitbook/assets/viewing-tabs-crashreport (1).gif>)
 

--- a/introduction/development/web-services/api/charting.md
+++ b/introduction/development/web-services/api/charting.md
@@ -42,17 +42,21 @@ This endpoint is deprecated and may be removed in the future. Use the [Dashboard
                 {
                     "day": 738387,
                     "timestamp": 1629417600,
-                    "totalCrashCount": 20
+                    "totalCrashCount": 20,
+                    "throttleCrashCount": 0,
+                    "retireCrashCount": 0
                 },
                 {
                     "day": 738388,
                     "timestamp": 1629504000,
-                    "totalCrashCount": 0
+                    "totalCrashCount": 0,
+                    "throttleCrashCount": 0,
+                    "retireCrashCount": 0
                 }
             ]
         }
     ]
-D}
+}
 ```
 {% endtab %}
 {% endtabs %}
@@ -91,7 +95,7 @@ Returns chartable volumes for a given database and a comma-separated list of sta
         "myConsoleCrasher!MemoryException(150)"
     ],
     [
-        "2021-07-26",
+        "2021-07-26T00:00:00Z",
         14
     ]
 ]

--- a/introduction/development/web-services/api/company.md
+++ b/introduction/development/web-services/api/company.md
@@ -14,9 +14,10 @@ Returns information about the queried company by companyId.
 
 #### Query Parameters
 
-| Name                                        | Type   | Description                |
-| ------------------------------------------- | ------ | -------------------------- |
-| companyId<mark style="color:red;">\*</mark> | number | ID of the company to query |
+| Name      | Type   | Description                                                      |
+| --------- | ------ | ------------------------------------------------------------------ |
+| companyId | number | ID of the company to query. Required if `database` is not provided. |
+| database  | string | Name of the database to resolve the company from. Required if `companyId` is not provided. |
 
 {% tabs %}
 {% tab title="200 " %}
@@ -26,6 +27,8 @@ Returns information about the queried company by companyId.
   companyName: "BugSplat Public Testing",
   subscriptionId: 1732,
   birthdate: "0000-00-00 00:00:00",
+  mfaRequired: false,
+  upgradePageShown: false,
   licensedLimitExceededCount: 0,
   licensedLimitExceededDate: null,
 }
@@ -48,9 +51,10 @@ Set the name of the specified company by companyId.
 
 #### Query Parameters
 
-| Name                                        | Type   | Description                 |
-| ------------------------------------------- | ------ | --------------------------- |
-| companyId<mark style="color:red;">\*</mark> | number | ID of the company to update |
+| Name      | Type   | Description                                                        |
+| --------- | ------ | -------------------------------------------------------------------- |
+| companyId | number | ID of the company to update. Required if `database` is not provided. |
+| database  | string | Name of the database to resolve the company from. Required if `companyId` is not provided. |
 
 #### Request Body
 
@@ -61,14 +65,7 @@ Set the name of the specified company by companyId.
 {% tabs %}
 {% tab title="200 " %}
 ```json
-{
-  companyId: 545,
-  companyName: "BugSplat Public Testing",
-  subscriptionId: 1732,
-  birthdate: "0000-00-00 00:00:00",
-  licensedLimitExceededCount: 0,
-  licensedLimitExceededDate: null
-}
+true
 ```
 {% endtab %}
 {% endtabs %}

--- a/introduction/development/web-services/api/crash-groups.md
+++ b/introduction/development/web-services/api/crash-groups.md
@@ -14,7 +14,7 @@ Get a summary of all [crash groups](../../../../education/bugsplat-terminology.m
 
 <mark style="color:blue;">`GET`</mark> `https://app.bugsplat.com/api/v2/summary`
 
-Returns crash summary data. Supports paging and filtering using column names firstReport, lastReport, stackKey, stackKeyId, crashSum, userSum, subKeyDepth, defectId, comments, and techSupportSubject.
+Returns crash summary data. Supports paging and filtering using column names firstReport, lastReport, stackKey, stackKeyId, crashSum, userSum, defectId, comments, and techSupportSubject.
 
 #### Query Parameters
 
@@ -26,9 +26,9 @@ Returns crash summary data. Supports paging and filtering using column names fir
 {% tab title="200 " %}
 ```json
 {
-    "Database": "tormore",
-    "PageData": null,
-    "Rows": [
+    "database": "tormore",
+    "pageData": null,
+    "rows": [
         {
             "stackKey": "myConsoleCrasher+0x12b5",
             "stackKeyId": "208",
@@ -40,8 +40,7 @@ Returns crash summary data. Supports paging and filtering using column names fir
             "defectId": null,
             "stackKeyDefectUrl": null,
             "stackKeyDefectLabel": null,
-            "comments": "Dave left a comment",
-            "subKeyDepth": "1"
+            "comments": "Dave left a comment"
         }
     ]
 }
@@ -123,6 +122,6 @@ Obtain a list of crashes for a specific crash group (also known as Stack Key). T
 ### Curl Example
 
 ```bash
-curl --location 'https://app.bugsplat.com/api/keycrash?database=fred&stackKeyId=10315' \
+curl --location 'https://app.bugsplat.com/api/v2/keycrash?database=fred&stackKeyId=10315' \
 --header 'Authorization: Bearer ••••••'
 ```

--- a/introduction/development/web-services/api/crash.md
+++ b/introduction/development/web-services/api/crash.md
@@ -254,7 +254,7 @@ curl --location 'https://app.bugsplat.com/api/crash/details?database=fred&id=132
 
 <mark style="color:green;">`POST`</mark> `https://app.bugsplat.com/api/crash/reprocess`
 
-Add a crash to BugSplat's queue for reprocessing. A maximum of 50 crashes can be in the queue for reprocessing. To reprocess more crashes, please [contact us](../../../../administration/contact-us.md).
+Add a crash to BugSplat's queue for reprocessing. A maximum of 60 crashes can be in the queue for reprocessing. To reprocess more crashes, please [contact us](../../../../administration/contact-us.md).
 
 #### Query Parameters
 
@@ -302,42 +302,10 @@ Update the notes field for a specific crash.
 {% tab title="200 " %}
 ```json
 {
+  "status": "success",
   "database": "Fred",
-  "pageData": {
-    "defectTracker": true,
-    "defectTrackerType": "GitHub"
-  },
-  "rows": [
-    {
-      "id": "140612",
-      "status": "0",
-      "stackId": "19187",
-      "stackKey": "myConsoleCrasher+0x12b5",
-      "stackKeyId": "9579",
-      "appName": "myConsoleCrasher",
-      "appVersion": "1.048",
-      "appDescription": "appKey",
-      "userDescription": "A default user description",
-      "user": "TestUser",
-      "email": "TestUser@bugsplat.com",
-      "IpAddress": "34.225.87.xxxx",
-      "crashTime": "2025-10-30T20:52:24Z",
-      "defectId": null,
-      "defectUrl": "",
-      "defectLabel": "",
-      "skDefectId": null,
-      "skDefectUrl": "",
-      "skDefectLabel": "",
-      "Comments": "",
-      "skComments": "",
-      "crashTypeId": "1",
-      "exceptionCode": "c0000005",
-      "exceptionMessage": "Access violation",
-      "attributes": "{}",
-      "lineNumber": null,
-      "groupByCount": null
-    }
-  ]
+  "id": 140612,
+  "notes": "test"
 }
 ```
 {% endtab %}

--- a/introduction/development/web-services/api/dashboard.md
+++ b/introduction/development/web-services/api/dashboard.md
@@ -17,8 +17,8 @@ Returns a consolidated dashboard summary for the specified database and time ran
 | Name        | Type   | Description                                                            |
 | ----------- | ------ | ---------------------------------------------------------------------- |
 | database    | string | **Required.** BugSplat database name                                   |
-| startDate   | string | ISO 8601 timestamp for the start of the time range. Omit for All Time. |
-| endDate     | string | ISO 8601 timestamp for the end of the time range. Omit for All Time.   |
+| startDate   | string | ISO 8601 timestamp for the start of the time range. If omitted, defaults to 365 days before `endDate`. |
+| endDate     | string | ISO 8601 timestamp for the end of the time range. If omitted, defaults to the current time.   |
 | appNames    | string | Comma-separated list of application names to filter by                 |
 | appVersions | string | Comma-separated list of application versions to filter by              |
 | timezone    | string | UTC offset (e.g. `+05:30`). Defaults to `+00:00`                       |
@@ -48,6 +48,7 @@ Returns a consolidated dashboard summary for the specified database and time ran
             }
         ]
     },
+    "lastCrashTime": "2026-02-20T12:05:00Z",
     "recentCrashes": [
         {
             "id": 1,
@@ -82,7 +83,9 @@ Returns a consolidated dashboard summary for the specified database and time ran
             "stackKeyId": 42,
             "crashSum": 150
         }
-    ]
+    ],
+    "totalThrottled": 3,
+    "totalThrottledPrevious": 2
 }
 ```
 {% endtab %}
@@ -97,9 +100,12 @@ Returns a consolidated dashboard summary for the specified database and time ran
 | volume30Day   | number | Total crash count in the last 30 days                                                         |
 | crashDataDays | number | Number of days of crash data available                                                        |
 | crashHistory  | object | Chart data for crash volume over time. Contains `totalRows`, `totalCrashes`, and `rows` array |
+| lastCrashTime | string | ISO 8601 timestamp of the most recent crash overall, not limited by the requested time range or filters. `null` if no crashes exist |
 | recentCrashes | array  | The 5 most recent crashes in the time range                                                   |
 | statusCounts  | object | Crash group status breakdown for `current` and `previous` time periods                        |
 | topStackKeys  | array  | Top 6 stack keys by crash count in the time range                                             |
+| totalThrottled | number | Total number of throttled crashes in the time range                                          |
+| totalThrottledPrevious | number | Total number of throttled crashes in the previous time period                        |
 
 ### Curl Example
 
@@ -108,12 +114,14 @@ curl --location 'https://app.bugsplat.com/api/dashboard?database=fred&startDate=
 --header 'Authorization: Bearer ••••••'
 ```
 
-### Curl Example (All Time)
+### Curl Example (Default Date Range)
 
 ```bash
 curl --location 'https://app.bugsplat.com/api/dashboard?database=fred' \
 --header 'Authorization: Bearer ••••••'
 ```
+
+Omitting `startDate` and `endDate` does not return all-time data; it defaults to the last 365 days.
 
 ### Curl Example (with filters)
 

--- a/introduction/development/web-services/api/databases.md
+++ b/introduction/development/web-services/api/databases.md
@@ -22,12 +22,23 @@ Returns databases for the current user or a company specified by companyId.
 {% tab title="200 " %}
 ```json
 [{
+    "uId": 55411,
+    "dbId": 25,
     "dbName": "Fred",
-    "companyId": "545",
+    "rights": 1,
+    "companyId": 545,
     "companyName": "BugSplat Public Testing",
-    "Volume30Day": "1075",
-    "Volume365Day": "8868",
-    "CrashDataDays": "6544"
+    "Rights": 1
+}]
+```
+{% endtab %}
+
+{% tab title="200 (companyId) " %}
+```json
+[{
+    "dbName": "Fred",
+    "companyId": 545,
+    "companyName": "BugSplat Public Testing"
 }]
 ```
 {% endtab %}

--- a/introduction/development/web-services/api/defect.md
+++ b/introduction/development/web-services/api/defect.md
@@ -42,11 +42,13 @@ Create an issue in the associated defect tracker
 
 #### Request Body
 
-| Name       | Type   | Description                                            |
-| ---------- | ------ | ------------------------------------------------------ |
-| stackKeyId | number | Id of the crash group being used to create a new issue |
-| id         | number | Id of the crash being used to create a new issue       |
-| database   | string | BugSplat database containing the crashId or stackKeyId |
+| Name         | Type   | Description                                                       |
+| ------------ | ------ | ------------------------------------------------------------------ |
+| stackKeyId   | number | Id of the crash group being used to create a new issue             |
+| id           | number | Id of the crash being used to create a new issue                   |
+| database     | string | BugSplat database containing the crashId or stackKeyId             |
+| notes        | string | Optional note attached to the new defect                           |
+| linkDefectId | string | Optional id of an existing defect to link instead of creating a new one |
 
 {% tabs %}
 {% tab title="200 " %}

--- a/introduction/development/web-services/api/events.md
+++ b/introduction/development/web-services/api/events.md
@@ -17,6 +17,7 @@ Get all events associated with a Crash Group (Stack Key).
 | Name       | Type   | Description                                                                        |
 | ---------- | ------ | ---------------------------------------------------------------------------------- |
 | database   | string | Name of the database containing the specified Crash Id or Crash Group (Stack Key). |
+| crashId    | number | Crash to fetch events for.                                                         |
 | stackKeyId | number | Crash group to fetch events for.                                                   |
 
 {% tabs %}
@@ -59,6 +60,7 @@ Post a new comment for a given Crash Group (Stack Key).
 | Name                                      | Type   | Description                                                                           |
 | ----------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
 | database                                  | string | Name of the database that contains the specified Crash Id or Crash Group (Stack Key). |
+| crashId                                   | number | Crash to comment on                                                                   |
 | message<mark style="color:red;">\*</mark> | string | Markdown string containing the body of the comment to post.                           |
 | stackKeyId                                | number | Crash group to comment on                                                             |
 

--- a/introduction/development/web-services/api/import-migrate.md
+++ b/introduction/development/web-services/api/import-migrate.md
@@ -28,11 +28,11 @@ Migrate crash minidump files to BugSplat from your existing crash report solutio
 
 {% tabs %}
 {% tab title="200: OK " %}
-```javascript
+```json
 {
-    status: "success",
-    crashId: 1,
-    techSupportUrl: "https://app.bugsplat.com/browse/crashInfo.php?vendor=Fred&version=1.0.0.0&key=*Default*&id=1&row=1"
+    "status": "success",
+    "crashId": 1,
+    "techSupportUrl": "https://app.bugsplat.com/browse/crashInfo.php?vendor=Fred&version=1.0.0.0&key=*Default*&id=1&row=1"
 }
 ```
 {% endtab %}

--- a/introduction/development/web-services/api/import-migrate.md
+++ b/introduction/development/web-services/api/import-migrate.md
@@ -32,7 +32,7 @@ Migrate crash minidump files to BugSplat from your existing crash report solutio
 {
     status: "success",
     crashId: 1,
-    techSupportUrl: "https://fred.bugsplat.com/browse/support/?stackKeyId=5555&vendor=Fred&key=*Default*"
+    techSupportUrl: "https://app.bugsplat.com/browse/crashInfo.php?vendor=Fred&version=1.0.0.0&key=*Default*&id=1&row=1"
 }
 ```
 {% endtab %}

--- a/introduction/development/web-services/api/support-response.md
+++ b/introduction/development/web-services/api/support-response.md
@@ -30,7 +30,8 @@ Returns the subject and raw markdown body contents for a Support Response page t
     "appKey": "*Default*",
     "subject": "",
     "content": "",
-    "allkeys": null
+    "allkeys": null,
+    "crashId": 12345
 }
 ```
 {% endtab %}
@@ -46,8 +47,8 @@ Create a new Support Response page for a specified stackKeyId and appKey.
 
 | Name                                         | Type   | Description                                                                                                                                |
 | -------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| content<mark style="color:red;">\*</mark>    | string | Markdown contents of the Support Response page's body.                                                                                     |
-| subject<mark style="color:red;">\*</mark>    | string | The subject line to be displayed to an end-user.                                                                                           |
+| content                                      | string | Markdown contents of the Support Response page's body.                                                                                     |
+| subject                                      | string | The subject line to be displayed to an end-user.                                                                                           |
 | appKey                                       | string | An appKey used to display a targeted version of the Support Response page. This is useful for displaying localized Support Response pages. |
 | stackKeyId<mark style="color:red;">\*</mark> | number | The Crash Group (Stack Key) ID of the specified crash                                                                                      |
 | database                                     | string | BugSplat database containing the specified crash                                                                                           |
@@ -76,8 +77,8 @@ Update a Support Response page for a specified stackKeyId and appKey.
 
 | Name                                         | Type   | Description                                                                                                                                |
 | -------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| content<mark style="color:red;">\*</mark>    | string | Markdown contents of the Support Response page's body.                                                                                     |
-| subject<mark style="color:red;">\*</mark>    | string | The subject line to be displayed to an end-user.                                                                                           |
+| content                                      | string | Markdown contents of the Support Response page's body.                                                                                     |
+| subject                                      | string | The subject line to be displayed to an end-user.                                                                                           |
 | appKey                                       | string | An appKey used to display a targeted version of the Support Response page. This is useful for displaying localized Support Response pages. |
 | stackKeyId<mark style="color:red;">\*</mark> | number | The Crash Group (Stack Key) ID of the specified crash                                                                                      |
 | database                                     | string | BugSplat database containing the specified crash                                                                                           |

--- a/introduction/development/web-services/api/users.md
+++ b/introduction/development/web-services/api/users.md
@@ -27,16 +27,15 @@ Returns a list of users and access rights for the specified database.
 ```json
 [
   {
-    "Database": "Fred",
-    "PageData": null,
-    "Rows": [
-      {
-        "uId": "55411",
-        "username": "fred@bugsplat.com",
-        "lastLogin": "2021-08-25T21:02:56Z",
-        "Restricted": "1"
-      }
-    ]
+    "dbId": 4321,
+    "dbName": "Fred",
+    "uId": 55411,
+    "username": "fred@bugsplat.com",
+    "firstName": "Fred",
+    "lastName": "Flintstone",
+    "lastLogin": "2021-08-25T21:02:56Z",
+    "unrestricted": 1,
+    "ssoGroups": ""
   }
 ]
 ```
@@ -54,21 +53,24 @@ curl --location 'https://app.bugsplat.com/api/user/users?database=fred' \
 
 <mark style="color:green;">`POST`</mark> `https://app.bugsplat.com/api/user/users`
 
-Adds a new user to the specified database.
+Adds a new user to the specified database. `PUT` is also accepted at this same endpoint and behaves identically, including updating the `rights` of an existing user.
 
 #### Request Body
 
-| Name     | Type   | Description                               |
-| -------- | ------ | ----------------------------------------- |
-| database | string | BugSplat database to add the user to      |
-| username | string | Email of user to be added to the database |
+| Name     | Type   | Description                                                                     |
+| -------- | ------ | -------------------------------------------------------------------------------- |
+| database | string | BugSplat database to add the user to                                            |
+| username | string | Email of user to be added to the database                                       |
+| rights   | number | Optional. `1` for unrestricted access, `0` for restricted access (default `0`)  |
 
 {% tabs %}
 {% tab title="200 " %}
 ```json
 {
     "status": "success",
-    "username": "fred@bugsplat.com",
+    "companyId": 1234,
+    "database": 4321,
+    "uId": 55411
 }
 ```
 {% endtab %}
@@ -95,7 +97,7 @@ Removes a user from the specified database. The authenticated user must not be r
 | Name     | Type   | Description                              |
 | -------- | ------ | ---------------------------------------- |
 | database | string | BugSplat database that contains the user |
-| username | number | Email of the user to remove              |
+| username | string | Email of the user to remove              |
 
 {% tabs %}
 {% tab title="200 " %}

--- a/introduction/development/web-services/api/versions.md
+++ b/introduction/development/web-services/api/versions.md
@@ -18,9 +18,11 @@ Returns a list of versions in a given database.
 
 #### Query Parameters
 
-| Name     | Type   | Description                                |
-| -------- | ------ | ------------------------------------------ |
-| database | string | BugSplat database containing symbol stores |
+| Name                  | Type   | Description                                                                   |
+| --------------------- | ------ | ------------------------------------------------------------------------------ |
+| database              | string | BugSplat database containing symbol stores                                    |
+| crashCountStartDate   | string | Optional start date used to compute periodCrashCount for the returned versions |
+| crashCountEndDate     | string | Optional end date used to compute periodCrashCount for the returned versions   |
 
 {% tabs %}
 {% tab title="200 " %}
@@ -40,7 +42,9 @@ Returns a list of versions in a given database.
       "reportsPerDay": null,
       "fullDumps": "0",
       "rejectedCount": "0",
-      "retired": "0"
+      "retired": "0",
+      "totalCrashCount": "0",
+      "periodCrashCount": "0"
     }
   ]
 }
@@ -51,7 +55,7 @@ Returns a list of versions in a given database.
 ### Curl Example
 
 ```bash
-curl --location 'https://app.bugsplat.com/api/versions?database=fred' \
+curl --location 'https://app.bugsplat.com/api/v2/versions?database=fred' \
 --header 'Authorization: Bearer ••••••'
 ```
 
@@ -65,11 +69,11 @@ Used to create a new version and returns a pre-signed URL that can be used to up
 
 | Name                                         | Type   | Description                                                                                                                          |
 | -------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| database                                     | string | BugSplat database in which the symbol store should be created                                                                        |
+| database<mark style="color:red;">\*</mark>  | string | BugSplat database in which the symbol store should be created                                                                        |
 | appVersion<mark style="color:red;">\*</mark> | string | Version of the application symbols being stored in the new symbol store                                                              |
 | appName<mark style="color:red;">\*</mark>    | string | Name of application symbols being stored in the new symbol store                                                                     |
-| symFileName                                  | string | Filename of the symbol file being uploaded to the symbol store via the returned pre-signed URL.                                      |
-| size                                         | number | Size of symbol file being uploaded to the symbol store via the returned pre-signed URL. Enter 0 to create a placeholder symbol store |
+| symFileName<mark style="color:red;">\*</mark> | string | Filename of the symbol file being uploaded to the symbol store via the returned pre-signed URL.                                      |
+| size<mark style="color:red;">\*</mark>       | number | Size of symbol file being uploaded to the symbol store via the returned pre-signed URL. Enter 0 to create a placeholder symbol store |
 
 {% tabs %}
 {% tab title="200 " %}
@@ -88,7 +92,7 @@ Used to create a new version and returns a pre-signed URL that can be used to up
 ### Curl Example
 
 ```bash
-curl --location 'https://app.bugsplat.com/api/versions' \
+curl --location 'https://app.bugsplat.com/api/v2/versions' \
 --header 'Authorization: Bearer ••••••' \
 --form 'database="fred"' \
 --form 'appName="Postman"' \
@@ -107,7 +111,7 @@ Used to set the retired and fullDumps flags for a specified version.
 
 | Name                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| database                                     | string | BugSplat database in which the symbol store should be created                                                                                                                                                                                                                                                                                                                         |
+| database<mark style="color:red;">\*</mark>  | string | BugSplat database in which the symbol store should be created                                                                                                                                                                                                                                                                                                                         |
 | appVersion<mark style="color:red;">\*</mark> | string | Version of application for which the retired/fullDumps flags should be updated                                                                                                                                                                                                                                                                                                        |
 | appName<mark style="color:red;">\*</mark>    | string | Name of application for which the retired/fullDumps flags should be updated                                                                                                                                                                                                                                                                                                           |
 | fullDumps                                    | 0\|1   | <p>Flag indicating that the BugSplat Native and .NET SDKs should generate and upload</p><p><a href="../../../getting-started/integrations/desktop/cplusplus/full-memory-dumps.md">full memory dumps</a></p><p>. This feature incurs additional costs.</p><p><a href="../../../../administration/contact-us.md">Contact us</a></p><p>to enable full memory dumps for your account.</p> |
@@ -144,7 +148,7 @@ Remove symbols from a specified version or versions.
 ### Curl Example
 
 ```bash
-curl --location --request DELETE 'https://app.bugsplat.com/api/versions?database=fred&appName=Postman&appVersion=1.2.3' \
+curl --location --request DELETE 'https://app.bugsplat.com/api/v2/versions?database=fred&appName=Postman&appVersion=1.2.3' \
 --header 'Authorization: Bearer ••••••'
 ```
 

--- a/introduction/development/web-services/crash.md
+++ b/introduction/development/web-services/crash.md
@@ -50,7 +50,7 @@ Requests a presigned URL for uploading a zip file to BugSplat's storage.
 {% tab title="429: Too Many Requests" %}
 ```json
 {
-    "error": "Too many requests"
+    "message": "Too many requests"
 }
 ```
 {% endtab %}
@@ -128,7 +128,11 @@ Commits the uploaded crash file for processing by BugSplat.
 
 ### Crash Type Reference
 
-Use the following `crashType` and `crashTypeId` values when committing uploads:
+Use the following `crashType` and `crashTypeId` values when committing uploads.
+
+{% hint style="warning" %}
+The `crashType` string field only recognizes the following values (case-insensitive): `Windows.Native`, `Windows.NET`, `Unity.Native`, `Xml.Report`, `Asan.Report`, `unity`, `User.Feedback`, and `Android.ANR`. Any other `crashType` string (e.g. `Java`, `Electron`, `UnityNative`, `XmlReport`) is silently treated as `Windows.Native`. For all other platforms listed below, pass the numeric `crashTypeId` instead.
+{% endhint %}
 
 | Platform              | crashType             | crashTypeId | Description                                      |
 | --------------------- | --------------------- | ----------- | ------------------------------------------------ |
@@ -137,7 +141,7 @@ Use the following `crashType` and `crashTypeId` values when committing uploads:
 | .NET                  | `DotNetDmp`           | 8           | .NET minidumps                                   |
 | .NET Standard         | `DotNetStandard`      | 18          | .NET Core, UWP, and .NET Standard                |
 | macOS                 | `PLCrashReporter`     | 13          | PLCrashReporter format                           |
-| Crashpad/Breakpad     | `Crashpad`            | 6           | Cross-platform Crashpad/Breakpad minidumps       |
+| Crashpad/Breakpad     | `Crashpad`            | 5           | Cross-platform Crashpad/Breakpad minidumps       |
 | Java                  | `Java`                | 4           | Java crash reports                               |
 | JavaScript            | `JavaScript`          | 14          | Browser JavaScript errors                        |
 | Angular               | `Angular`             | 19          | Angular framework errors                         |
@@ -184,8 +188,8 @@ Uploads a Playstation 4 crash report, extracts user data and user files
 | Name                                          | Type   | Description                                                                                                                             |
 | --------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | corefile<mark style="color:red;">\*</mark>    | object | The core dump file to be uploaded                                                                                                       |
-| application<mark style="color:red;">\*</mark> | string | <p>Name of the crashing application.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols.</p> |
-| version<mark style="color:red;">\*</mark>     | string | <p>Crashing application's version.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols</p>    |
+| application                                    | string | <p>Name of the crashing application. Defaults to "unknown" if omitted.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols.</p> |
+| version                                        | string | <p>Crashing application's version. Defaults to "unknown" if omitted.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols</p>    |
 
 {% tabs %}
 {% tab title="200 " %}
@@ -216,8 +220,8 @@ Uploads a Playstation 5 crash report, extracts user data and user files
 | Name                                          | Type   | Description                                                                                                                             |
 | --------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | corefile<mark style="color:red;">\*</mark>    | object | The core dump file to be uploaded                                                                                                       |
-| application<mark style="color:red;">\*</mark> | string | <p>Name of the crashing application.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols.</p> |
-| version<mark style="color:red;">\*</mark>     | string | <p>Crashing application's version.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols</p>    |
+| application                                    | string | <p>Name of the crashing application. Defaults to "unknown" if omitted.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols.</p> |
+| version                                        | string | <p>Crashing application's version. Defaults to "unknown" if omitted.</p><p><strong>IMPORTANT</strong></p><p>this value must match the value used to upload symbols</p>    |
 
 {% tabs %}
 {% tab title="200 " %}

--- a/introduction/development/web-services/oauth2.md
+++ b/introduction/development/web-services/oauth2.md
@@ -42,7 +42,7 @@ Exchange a Client Id and Client Secret for a bearer token.
 ```
 {
   "token_type": "Bearer",
-  "expires_in": 3600,
+  "expires_in": 86400,
   "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9[...]"
 }
 ```

--- a/introduction/development/web-services/paging-filtering-and-grouping.md
+++ b/introduction/development/web-services/paging-filtering-and-grouping.md
@@ -7,7 +7,7 @@ The following URI parameters may be available:
 * **sortdatafield** - the sort column's datafield.
 * **sortorder** - the sort order - 'asc' or 'desc'
 * **pagenum** - the current page number when the paging feature is enabled. The first page is number 0.
-* **pagesize** - the number of rows in one page of data. Pagesize defaults to 100 and is capped at 10,000.
+* **pagesize** - the number of rows in one page of data. Pagesize defaults to 10 and is capped at 100,000.
 * **filterscount** - the number of filters in the query. Defaults to 0.
 * **filterdatafield#** - the filter column's datafield, or column name.
 * **filtervalue#** - the filter's value. The name for the first filter is "filtervalue0", for the second is "filtervalue1" and so on.

--- a/introduction/development/web-services/platform-specific-apis/README.md
+++ b/introduction/development/web-services/platform-specific-apis/README.md
@@ -2,11 +2,11 @@
 
 Here is the current BugSplat API documentation
 
-{% embed url="https://www.bugsplat.com/platforms/cpp/api" %}
+{% embed url="https://docs.bugsplat.com/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation" %}
 Latest version
 {% endembed %}
 
-{% embed url="https://www.bugsplat.com/platforms/cpp/api" %}
+{% embed url="https://docs.bugsplat.com/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation" %}
 This is our legacy link
 {% endembed %}
 

--- a/introduction/development/web-services/platform-specific-apis/README.md
+++ b/introduction/development/web-services/platform-specific-apis/README.md
@@ -6,8 +6,6 @@ Here is the current BugSplat API documentation
 Latest version
 {% endembed %}
 
-{% embed url="https://docs.bugsplat.com/introduction/getting-started/integrations/desktop/cplusplus/bugsplat-for-windows-api-documentation" %}
-This is our legacy link
-{% endembed %}
+<!-- Legacy embed removed (duplicate of 'Latest version') -->
 
 

--- a/introduction/development/web-services/platform-specific-apis/README.md
+++ b/introduction/development/web-services/platform-specific-apis/README.md
@@ -11,5 +11,3 @@ This is our legacy link
 {% endembed %}
 
 
-
-{% embed url="https://www.bugsplat.com/platforms/net/api" %}

--- a/introduction/development/web-services/user-feedback.md
+++ b/introduction/development/web-services/user-feedback.md
@@ -41,8 +41,10 @@ Special XML characters in title and description (`&`, `<`, `>`, `"`, `'`) must b
 
 | Field         | Required | Description                                         |
 | ------------- | -------- | --------------------------------------------------- |
-| `title`       | Yes      | Short summary of the feedback (becomes stack key)   |
-| `description` | No       | Detailed description of the issue (can be empty)    |
+| `title`       | No\*     | Short summary of the feedback (becomes stack key); if omitted, a truncated `description` is used instead |
+| `description` | No\*     | Detailed description of the issue (can be empty)    |
+
+\* At least one of `title` or `description` must be provided.
 
 ## Uploading via Presigned URL
 
@@ -60,11 +62,10 @@ Optional fields on commit: `user`, `email`, `description`, `appKey`, `attributes
 
 ## JS API Client
 
-The [`bugsplat-js-api-client`](https://github.com/BugSplat-Git/bugsplat-js-api-client) package provides a `postUserFeedback()` helper that handles XML generation and upload:
+The [`@bugsplat/js-api-client`](https://github.com/BugSplat-Git/bugsplat-js-api-client) package provides a `postUserFeedback()` helper that handles JSON generation and upload:
 
 ```typescript
-import { CrashPostClient } from 'bugsplat-js-api-client';
-import { postUserFeedback } from 'bugsplat-js-api-client/src/post/user-feedback';
+import { CrashPostClient, postUserFeedback } from '@bugsplat/js-api-client';
 
 const client = new CrashPostClient('your-database');
 
@@ -75,3 +76,7 @@ await postUserFeedback(client, 'MyApp', '1.0.0', {
     email: 'jane@example.com',
 });
 ```
+
+{% hint style="warning" %}
+`postUserFeedback()` currently uploads the raw `feedback.json` payload without zipping it. Since the presigned upload URL always targets a `.zip` key and the backend expects a zip archive, reports submitted this way will not process correctly. Until this is fixed, use the manual upload flow described above with a zipped `feedback.xml` or `feedback.json` file.
+{% endhint %}

--- a/introduction/development/web-services/user-feedback.md
+++ b/introduction/development/web-services/user-feedback.md
@@ -60,23 +60,126 @@ Use `crashType=User.Feedback` (or `crashTypeId=36`) when committing the upload i
 
 Optional fields on commit: `user`, `email`, `description`, `appKey`, `attributes`
 
-## JS API Client
+## Python Upload Example
 
-The [`@bugsplat/js-api-client`](https://github.com/BugSplat-Git/bugsplat-js-api-client) package provides a `postUserFeedback()` helper that handles JSON generation and upload:
+```py
+import hashlib
+import os
+import requests
+import sys
+import zipfile
 
-```typescript
-import { CrashPostClient, postUserFeedback } from '@bugsplat/js-api-client';
+# Usage: python upload_feedback.py <database> <application> <version> <feedback.xml|feedback.json>
 
-const client = new CrashPostClient('your-database');
+def main():
+    if len(sys.argv) != 5:
+        print_usage()
+        exit(1)
 
-await postUserFeedback(client, 'MyApp', '1.0.0', {
-    title: 'Login button does not respond',
-    description: 'Tapping login on iPhone does nothing.',
-    user: 'jane@example.com',
-    email: 'jane@example.com',
-});
+    database = sys.argv[1]
+    application = sys.argv[2]
+    version = sys.argv[3]
+    file = sys.argv[4]
+
+    if not os.path.exists(file):
+        print(f"Error: The file {file} does not exist.")
+        exit(1)
+
+    if not (file.endswith(".xml") or file.endswith(".json")):
+        print(f"Error: The file {file} must be feedback.xml or feedback.json.")
+        exit(1)
+
+    upload_user_feedback(database, application, version, file)
+
+
+def upload_user_feedback(database, application, version, file):
+    zip_file = ""
+    try:
+        zip_file = create_zip(file)
+        file_size = os.path.getsize(zip_file)
+        upload_url = get_crash_upload_url(database, application, version, file_size)
+        crash_type = "User.Feedback"
+        crash_type_id = 36
+        upload_file_md5 = get_md5_hash(zip_file)
+        upload_file_to_presigned_url(upload_url, zip_file)
+        commit_s3_crash_upload(
+            upload_url,
+            database,
+            application,
+            version,
+            crash_type,
+            crash_type_id,
+            upload_file_md5,
+        )
+        print("Uploaded user feedback successfully")
+    except Exception as e:
+        print(e)
+    finally:
+        if zip_file and os.path.exists(zip_file):
+            os.remove(zip_file)
+
+
+def commit_s3_crash_upload(s3_key, database, application, version, crash_type, crash_type_id, md5):
+    route = f"https://{database}.bugsplat.com/api/commitS3CrashUpload"
+    files = {
+        "database": (None, database),
+        "appName": (None, application),
+        "appVersion": (None, version),
+        "crashType": (None, crash_type),
+        "crashTypeId": (None, str(crash_type_id)),
+        "s3key": (None, s3_key),
+        "md5": (None, md5),
+    }
+
+    response = requests.post(route, files=files)
+    if response.status_code != 200:
+        raise Exception(f"Failed to commit S3 crash upload: {response.text}")
+    return response.json()
+
+
+def create_zip(file):
+    zip_filename = file + ".zip"
+    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+        zipf.write(file, os.path.basename(file))
+    return zip_filename
+
+
+def get_crash_upload_url(database, application, version, size):
+    route = f"https://{database}.bugsplat.com/api/getCrashUploadUrl?database={database}&appName={application}&appVersion={version}&crashPostSize={size}"
+    response = requests.get(route)
+    if response.status_code == 429:
+        raise Exception("Failed to get crash upload URL, too many requests")
+    if response.status_code != 200:
+        raise Exception("Failed to get crash upload URL")
+    json_response = response.json()
+    return json_response["url"]
+
+
+def get_md5_hash(file_path):
+    hash_md5 = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
+def print_usage():
+    print("Usage: python upload_feedback.py <database> <application> <version> <feedback.xml|feedback.json>")
+
+
+def upload_file_to_presigned_url(presigned_url, file_path, additional_headers={}):
+    file_size = os.path.getsize(file_path)
+    headers = {
+        "content-type": "application/octet-stream",
+        "content-length": str(file_size),
+        **additional_headers,
+    }
+    with open(file_path, "rb") as file:
+        response = requests.put(presigned_url, headers=headers, data=file)
+        if response.status_code != 200:
+            raise Exception(f"Error uploading to presigned URL {presigned_url}")
+        return response
+
+
+main()
 ```
-
-{% hint style="warning" %}
-`postUserFeedback()` currently uploads the raw `feedback.json` payload without zipping it. Since the presigned upload URL always targets a `.zip` key and the backend expects a zip archive, reports submitted this way will not process correctly. Until this is fixed, use the manual upload flow described above with a zipped `feedback.xml` or `feedback.json` file.
-{% endhint %}

--- a/introduction/development/working-with-symbol-files/how-to-manually-upload-symbols.md
+++ b/introduction/development/working-with-symbol-files/how-to-manually-upload-symbols.md
@@ -20,7 +20,7 @@ Enter values in the **Application** and **Version** fields if they are displayed
 
 Drag and drop the files you would like to upload, or use the **Select Files** link to choose the files in your system file explorer.
 
-Choose all of the symbol files that correspond to your application. Windows symbol files have `.exe`, `.dll`, and `.pdb` file extensions. MacOS symbol files can be extracted from a `.xcarchive` (must be zipped before uploading), or you can upload `.dSYM` files. Crashpad and Breakpad symbol files have a `.sym` file extension. TypeScript and JavaScript symbol files have a `.js.map` extension.
+Choose all of the symbol files that correspond to your application. Windows symbol files have `.exe`, `.dll`, and `.pdb` file extensions. MacOS symbol files can be extracted from a `.xcarchive`, or you can upload `.dSYM` files. Crashpad and Breakpad symbol files have a `.sym` file extension. TypeScript and JavaScript symbol files have a `.js.map` extension.
 
 ## Step 5
 

--- a/introduction/development/working-with-symbol-files/symbol-servers.md
+++ b/introduction/development/working-with-symbol-files/symbol-servers.md
@@ -50,6 +50,6 @@ For AWS S3 symbol servers, create a minimally permissive [IAM User](https://docs
 }
 ```
 
-Once you create your IAM user, generate an [access key/secret](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) to allow BugSplat to access your S3 bucket. Navigate to the [Symbols](https://app.bugsplat.com/v2/database/symbols) page and click **+ Add Server**. Select **AWS-S3** in the **Type** dropdown. Enter values for **URL**, **Region**, **Access Key**, **Secret Key**, and click **OK.**
+Once you create your IAM user, generate an [access key/secret](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) to allow BugSplat to access your S3 bucket. Navigate to the [Symbols](https://app.bugsplat.com/v2/database/symbols) page and click **+ Add Server**. Select **AWS-S3** in the **Type** dropdown. Enter values for **Access Key**, **Secret Key**, **Region**, and **Bucket Name**, and click **Add.**
 
 <figure><img src="../../../.gitbook/assets/output (1) (1).gif" alt=""><figcaption><p>Adding an External S3 Symbol Server</p></figcaption></figure>

--- a/introduction/development/working-with-symbol-files/working-with-windows-symbols-in-bugsplat.md
+++ b/introduction/development/working-with-symbol-files/working-with-windows-symbols-in-bugsplat.md
@@ -10,7 +10,7 @@ At the top of the Crash page, you will see a warning if you're missing symbols.
 
 ![Missing Symbols Alert](../../../.gitbook/assets/windows-symbols-missing-symbols.png)
 
-Once the data is obtained, the Function, Location, Code, OS, and Explanation fields will be populated with all available information. If a crash is missing symbols, there will be various messages under the 'File' column in the 'Active Thread' tab indicating which symbols were missing. Make sure to upload the missing symbols (`.exe`,`.pdb`, and `.dll` files as indicated by the 'Active Thread' tab) to the symbol store for your application name and version via the [Versions](https://app.bugsplat.com/v2/versions) page.  Or use [symbol-upload](../../../education/faq/how-to-upload-symbol-files-with-symbol-upload.md) to upload symbols using the command line.  When uploading using [symbol-upload](https://docs.bugsplat.com/education/faq/how-to-upload-symbol-files-with-symbol-upload), symbols are matched to crashes by their internal GUID — the application name and version used when uploading do not need to match those of the crash report.
+Once the data is obtained, the Function, Location, Exception Code, Environment, and Exception Message fields will be populated with all available information. If a crash is missing symbols, there will be various messages under the 'File' column in the 'Active Thread' tab indicating which symbols were missing. Make sure to upload the missing symbols (`.exe`,`.pdb`, and `.dll` files as indicated by the 'Active Thread' tab) to the symbol store for your application name and version via the [Versions](https://app.bugsplat.com/v2/versions) page.  Or use [symbol-upload](../../../education/faq/how-to-upload-symbol-files-with-symbol-upload.md) to upload symbols using the command line.  When uploading using [symbol-upload](https://docs.bugsplat.com/education/faq/how-to-upload-symbol-files-with-symbol-upload), symbols are matched to crashes by their internal GUID — the application name and version used when uploading do not need to match those of the crash report.
 
 ![Missing Symbols in Active Thread](../../../.gitbook/assets/windows-symbols-active-thread.png)
 
@@ -22,8 +22,8 @@ The values under the status column are as follows:
 
 * **deferred**: the debugger doesn’t need the module’s exe, dll, or pdb files to unwind the stack.
 * **file not found**: the debugger needs the module’s exe, dll, or pdb files to unwind the stack, but the exe/dll with matching debug signature cannot be located.
-* **symbols not found**: the debugger needs the module’s exe, dll, or pdb files to unwind the stack and the matching exe/dll has been located, but not the symbols.
-* **pdb symbols**: debugger needs the module’s exe, dll, or pdb files to unwind the stack and they have been loaded successfully.
+* **no symbols loaded**: the debugger needs the module’s exe, dll, or pdb files to unwind the stack and the matching exe/dll has been located, but not the symbols.
+* **pdb symbols** (or **private pdb symbols**): debugger needs the module’s exe, dll, or pdb files to unwind the stack and they have been loaded successfully.
 
 Unfortunately, Microsoft doesn’t provide symbol information for all operating system modules, so “file not found” errors are fairly common.
 


### PR DESCRIPTION
Applies verified fixes from the July 2026 docs audit to **34 pages** in this section.

Every change is grounded in the current state of the product code or SDK repos (the audit findings carry file:line evidence). Screenshot/media updates are **not** in this PR — those are deferred to a separate follow-up.

## Pages fixed

- `introduction/development/commenting.md` (#208)
- `introduction/development/grouping-crashes.md` (#209)
- `introduction/development/integrating-with-tools/issue-trackers/automatic-issue-creation.md` (#210)
- `introduction/development/integrating-with-tools/issue-trackers/azure-devops.md` (#211)
- `introduction/development/integrating-with-tools/issue-trackers/favro.md` (#212)
- `introduction/development/integrating-with-tools/issue-trackers/github-issues.md` (#213)
- `introduction/development/integrating-with-tools/issue-trackers/jira.md` (#215)
- `introduction/development/integrating-with-tools/issue-trackers/youtrack.md` (#217)
- `introduction/development/integrating-with-tools/messanger-apps/email.md` (#219)
- `introduction/development/integrating-with-tools/messanger-apps/microsoft-teams.md` (#220)
- `introduction/development/integrating-with-tools/messanger-apps/slack.md` (#221)
- `introduction/development/integrating-with-tools/messanger-apps/webhook.md` (#222)
- `introduction/development/searching/search.md` (#224)
- `introduction/development/using-the-app.md` (#225)
- `introduction/development/web-services/api/charting.md` (#226)
- `introduction/development/web-services/api/company.md` (#227)
- `introduction/development/web-services/api/crash-groups.md` (#228)
- `introduction/development/web-services/api/crash.md` (#229)
- `introduction/development/web-services/api/dashboard.md` (#230)
- `introduction/development/web-services/api/databases.md` (#231)
- `introduction/development/web-services/api/defect.md` (#232)
- `introduction/development/web-services/api/events.md` (#233)
- `introduction/development/web-services/api/import-migrate.md` (#234)
- `introduction/development/web-services/api/support-response.md` (#235)
- `introduction/development/web-services/api/users.md` (#236)
- `introduction/development/web-services/api/versions.md` (#237)
- `introduction/development/web-services/crash.md` (#238)
- `introduction/development/web-services/oauth2.md` (#239)
- `introduction/development/web-services/paging-filtering-and-grouping.md` (#240)
- `introduction/development/web-services/platform-specific-apis/README.md` (#241) — *one finding left open, see issue*
- `introduction/development/web-services/user-feedback.md` (#242)
- `introduction/development/working-with-symbol-files/how-to-manually-upload-symbols.md` (#244)
- `introduction/development/working-with-symbol-files/symbol-servers.md` (#245)
- `introduction/development/working-with-symbol-files/working-with-windows-symbols-in-bugsplat.md` (#246)

## Closes

Fixes #208
Fixes #209
Fixes #210
Fixes #211
Fixes #212
Fixes #213
Fixes #215
Fixes #217
Fixes #219
Fixes #220
Fixes #221
Fixes #222
Fixes #224
Fixes #225
Fixes #226
Fixes #227
Fixes #228
Fixes #229
Fixes #230
Fixes #231
Fixes #232
Fixes #233
Fixes #234
Fixes #235
Fixes #236
Fixes #237
Fixes #238
Fixes #239
Fixes #240
Fixes #241
Fixes #242
Fixes #244
Fixes #245
Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)