### PR TITLE
docs: fix Getting Started docs — 7 pages (7 issues)

### DIFF
--- a/introduction/getting-started/adding-uses-to-your-account.md
+++ b/introduction/getting-started/adding-uses-to-your-account.md
@@ -6,7 +6,7 @@ After signing up for a BugSplat account, it’s important to add your team membe
 
 To add a team member to all your company's databases, simply add them via the [Company](https://app.bugsplat.com/v2/company) page. They will receive an email providing a prompt about setting up their account.
 
-## Adding Team Members to a Specific Databases ⚽
+## Adding Team Members to Specific Databases ⚽
 
 Only need to add a team member to a specific subset of databases? Select the desired database, then navigate to its [Users](https://app.bugsplat.com/v2/database/users) page in Settings.
 

--- a/introduction/getting-started/adding-uses-to-your-account.md
+++ b/introduction/getting-started/adding-uses-to-your-account.md
@@ -8,11 +8,11 @@ To add a team member to all your company's databases, simply add them via the [C
 
 ## Adding Team Members to a Specific Databases ⚽
 
-Only need to add a team member to a specific subset of databases? Navigate to the [Manage Users](https://app.bugsplat.com/v2/company/users) page in Settings and select the desired database from the dropdown selector.
+Only need to add a team member to a specific subset of databases? Select the desired database, then navigate to its [Users](https://app.bugsplat.com/v2/database/users) page in Settings.
 
 ![Adding Team Members](../../.gitbook/assets/help-adding-users.png)
 
-Once you've selected the right database, click the `Add User` button. This will prompt you to insert an email address of your team member. Once invited, they will receive an email allowing them to set up their account.
+Once you've navigated to the Users page for the right database, click the `Add Users` button. This will prompt you to insert an email address of your team member. Once invited, they will receive an email allowing them to set up their account.
 
 Repeat this process for all desired databases.
 

--- a/introduction/getting-started/create-a-new-database-in-bugsplat.md
+++ b/introduction/getting-started/create-a-new-database-in-bugsplat.md
@@ -6,7 +6,7 @@ To start using BugSplat, you'll need to create a database. You can create a data
 
 ### Create a Database via the Onboarding Tool 🧑‍🏫
 
-For new BugSplat users, creating a new database can be accomplished via the Onboarding process. After creating a new account, users will be prompted to create a database. You can return to the Onboarding process any time by clicking the bug in the top left corner.
+For new BugSplat users, creating a new database can be accomplished via the Onboarding process. After creating a new account, users will be prompted to create a database. You can return to the Onboarding process any time by navigating to the [Onboarding Tool](https://app.bugsplat.com/v2/welcome).
 
 <figure><img src="../../.gitbook/assets/onboarding-create-database.png" alt=""><figcaption><p>Create a Database via the Onboarding Tool</p></figcaption></figure>
 

--- a/introduction/getting-started/posting-a-test-crash/README.md
+++ b/introduction/getting-started/posting-a-test-crash/README.md
@@ -2,13 +2,13 @@
 
 Sample applications to produce a test crash for testing BugSplat implementations.
 
-Questions? Please get in touch with us via [Discord](https://discord.gg/K4KjjRV5ve) or at [support@bugsplat.com](mailto:support@bugplat.com).
+Questions? Please get in touch with us via [Discord](https://discord.gg/K4KjjRV5ve) or at [support@bugsplat.com](mailto:support@bugsplat.com).
 
 | Platform      | Sample                                                                                     |
 | ------------- | ------------------------------------------------------------------------------------------ |
 | Android       | [my-android-crasher](https://github.com/BugSplat-Git/my-android-crasher)                   |
 | Angular       | [my-angular-crasher](https://github.com/BugSplat-Git/bugsplat-ng)                          |
-| CMake         | [my-cmake-crasher](https://github.com/BugSplat-Git/my-cmake-crasher)                       |
+| CMake         | [bugsplat-crashpad](https://github.com/BugSplat-Git/bugsplat-crashpad)                     |
 | Electron      | [my-electron-crasher](https://github.com/BugSplat-Git/my-electron-crasher)                 |
 | iOS           | [BugSplatTester](https://github.com/BugSplat-Git/bugsplat-apple/tree/main/Example_Apps)    |
 | Java          | [my-java-crasher](https://github.com/BugSplat-Git/bugsplat-java/tree/main/my-java-crasher) |
@@ -16,7 +16,7 @@ Questions? Please get in touch with us via [Discord](https://discord.gg/K4KjjRV5
 | Node.js       | [my-node-crasher](https://github.com/BugSplat-Git/my-node-crasher)                         |
 | Python        | [my-python-crasher](https://github.com/BugSplat-Git/my-python-crasher)                     |
 | Qt            | [my-qt-crasher](https://github.com/BugSplat-Git/my-qt-crasher)                             |
-| React         | [my-react-crasher](https://github.com/BugSplat-Git/my-react-crasher)                       |
+| React         | [bugsplat-react](https://github.com/BugSplat-Git/bugsplat-react)                           |
 | Unity         | [my-unity-crasher](https://github.com/BugSplat-Git/my-unity-crasher)                       |
 | Unreal        | [my-unreal-crasher](https://github.com/BugSplat-Git/my-unreal-crasher)                     |
 | Windows (C++) | [my-console-crasher](myconsolecrasher-c-plus-plus/)                                        |

--- a/introduction/getting-started/posting-a-test-crash/myconsolecrasher-c-plus-plus/address-sanitizer-reports.md
+++ b/introduction/getting-started/posting-a-test-crash/myconsolecrasher-c-plus-plus/address-sanitizer-reports.md
@@ -14,7 +14,7 @@ Modify the Visual Studio Include Directories so that the Address Sanitizer heade
 
 ## Modify Initialization Code
 
-To hook into the Address Sanitizer you will call **\_\_asan\_set\_error\_report\_callback** with the BugSplat **createAssanReport** method. To do this, we'll need a global instance of the BugSplat MiniDmpSender object and a new asanCallback function. See below for how you would modify our myConsoleCrasher sample program:
+To hook into the Address Sanitizer you will call **\_\_asan\_set\_error\_report\_callback** with the BugSplat **CreateAsanReport** method. To do this, we'll need a global instance of the BugSplat object and a new asanCallback function. See below for how you would modify our myConsoleCrasher sample program:
 
 ```cpp
 ...
@@ -22,11 +22,11 @@ To hook into the Address Sanitizer you will call **\_\_asan\_set\_error\_report\
 ...
 
 // Global BugSplat initialization. 
-MiniDmpSender* mpSender = new MiniDmpSender(L"YourDatabase", L"YourAppName", L"YourAppVersion", NULL, MDSF_USEGUARDMEMORY | MDSF_LOGFILE | MDSF_PREVENTHIJACKING);
+BugSplat g_BugSplat(L"YourDatabase", L"YourAppName", L"YourAppVersion");
 
 void asanCallback(const char* message)
 {
-   mpSender->createAsanReport(message);
+   g_BugSplat.CreateAsanReport(message);
 }
 
 int wmain(int argc, wchar_t** argv)

--- a/introduction/getting-started/quickly-submitting-your-first-crash-in-under-5-minutes.md
+++ b/introduction/getting-started/quickly-submitting-your-first-crash-in-under-5-minutes.md
@@ -4,9 +4,10 @@ Submitting a sample crash to your new BugSplat account is a quick and straightfo
 
 1. [Sign up ](https://app.bugsplat.com/v2/sign-up)for a new account
 2. Use the onboarding tool to create a new database
-3. Select your first platform or SDK from our list of 25+ SDKs
-4. Select the "In a Hurry" button at the bottom right of the docs to skip the full integration process for now and post a sample crash
-5. Explore your new BugSplat account and see the data you can get from a crashed app
+3. Add tools and team members
+4. Select your first platform or SDK from our list of 25+ SDKs
+5. Select the "Post sample crash" button to skip the full integration process for now and post a sample crash
+6. Explore your new BugSplat account and see the data you can get from a crashed app
 
 ### Step 1: Sign Up for a New Account
 
@@ -30,7 +31,7 @@ BugSplat supports [a wide range of platforms and SDKs](integrations/), providing
 
 ### Step 4: Submitting a Sample Crash
 
-Once you've selected your platform or SDK, you'll be taken to our documentation page. To quickly submit a sample crash without going through the full integration process, scroll down to the bottom right of the page and click the button labeled "**In a hurry? Post a sample crash instead**." This allows you to skip the full integration process for now and submit a sample crash directly.
+Once you've selected your platform or SDK, you'll be taken to our documentation page. To quickly submit a sample crash without going through the full integration process, click the "**Post sample crash**" button in the sidebar status card. This allows you to skip the full integration process for now and submit a sample crash directly.
 
 <figure><img src="../../.gitbook/assets/post_sample_crash-4.png" alt="" width="563"><figcaption></figcaption></figure>
 
@@ -38,7 +39,7 @@ Once you've selected your platform or SDK, you'll be taken to our documentation 
 
 Congratulations! You've successfully submitted a sample crash to your new BugSplat account. Take a moment to explore your BugSplat account and discover the valuable data you can obtain from a crashed application. This data will empower you to identify and resolve issues in your software more efficiently, saving you time and energy in the long run.
 
-Remember, if you want to navigate back to the onboarding flow and complete the full integration process with BugSplat, you can do so at any time by clicking the BugSplat logo in the top left corner of the screen.  You can also click this link --> [https://app.bugsplat.com/v2/welcome](https://app.bugsplat.com/v2/welcome)
+Remember, if you want to navigate back to the onboarding flow and complete the full integration process with BugSplat, you can do so at any time by clicking this link --> [https://app.bugsplat.com/v2/welcome](https://app.bugsplat.com/v2/welcome)
 
 <figure><img src="../../.gitbook/assets/post_sample_crash-5.png" alt="" width="563"><figcaption></figcaption></figure>
 

--- a/introduction/getting-started/quickly-submitting-your-first-crash-in-under-5-minutes.md
+++ b/introduction/getting-started/quickly-submitting-your-first-crash-in-under-5-minutes.md
@@ -21,7 +21,11 @@ After signing up, you'll be directed to the BugSplat onboarding tool. This tool 
 
 <figure><img src="../../.gitbook/assets/post_sample_crash-2.png" alt="" width="563"><figcaption></figcaption></figure>
 
-### Step 3: Select Your First Platform or SDK
+### Step 3: Add Tools and Team Members
+
+Before selecting a platform or SDK, use the onboarding tool to add your development tools and team members.
+
+### Step 4: Select Your First Platform or SDK
 
 BugSplat supports [a wide range of platforms and SDKs](integrations/), providing comprehensive crash reporting capabilities. Choose your platform or SDK from our extensive list of over 25 options. Select the one that matches your application's development environment.
 
@@ -29,13 +33,13 @@ BugSplat supports [a wide range of platforms and SDKs](integrations/), providing
 
 <figure><img src="../../.gitbook/assets/post_sample_crash-3.png" alt="" width="563"><figcaption></figcaption></figure>
 
-### Step 4: Submitting a Sample Crash
+### Step 5: Submitting a Sample Crash
 
 Once you've selected your platform or SDK, you'll be taken to our documentation page. To quickly submit a sample crash without going through the full integration process, click the "**Post sample crash**" button in the sidebar status card. This allows you to skip the full integration process for now and submit a sample crash directly.
 
 <figure><img src="../../.gitbook/assets/post_sample_crash-4.png" alt="" width="563"><figcaption></figcaption></figure>
 
-### Step 5: Explore Your New BugSplat Account
+### Step 6: Explore Your New BugSplat Account
 
 Congratulations! You've successfully submitted a sample crash to your new BugSplat account. Take a moment to explore your BugSplat account and discover the valuable data you can obtain from a crashed application. This data will empower you to identify and resolve issues in your software more efficiently, saving you time and energy in the long run.
 

--- a/introduction/getting-started/signing-up-for-an-account-with-bugsplat.md
+++ b/introduction/getting-started/signing-up-for-an-account-with-bugsplat.md
@@ -1,6 +1,6 @@
 # Signing Up
 
-To register an account with BugSplat, visit the [Sign Up](https://app.bugsplat.com/v2/sign-up) page and enter in your company email or another email you wish to be associated with your account.
+To register an account with BugSplat, visit the [Sign Up](https://app.bugsplat.com/v2/sign-up) page and enter your first name, last name, company email (or another email you wish to be associated with your account), and a password. Passwords must be 14-64 characters and include an uppercase letter, a lowercase letter, a number, and a symbol. You'll be asked to re-enter your password to confirm it.
 
 ![](<../../.gitbook/assets/Screen Shot 2021-08-24 at 9.55.33 AM.png>)
 

--- a/introduction/getting-started/troubleshooting.md
+++ b/introduction/getting-started/troubleshooting.md
@@ -22,7 +22,7 @@ Corporate firewalls or network policies can prevent connections to BugSplat. Ple
 
 ### The crash being uploaded is too large
 
-By default BugSplat accounts are limited to posting crash uploads that are no larger than 20MB (compressed). Abnormally large minidump, log files, and/or other attachments can cause crash uploads to be larger than your account's crash upload size limit. You can view BugSplat's [Errors](https://app.bugsplat.com/v2/errors) page to see if crash reports are being rejected due to size limit restrictions.
+By default BugSplat accounts are limited to posting crash uploads that are no larger than 100MB (compressed), with an additional 10MB allowance for .NET applications. Abnormally large minidump, log files, and/or other attachments can cause crash uploads to be larger than your account's crash upload size limit. You can view BugSplat's [Errors](https://app.bugsplat.com/v2/errors) page to see if crash reports are being rejected due to size limit restrictions.
 
 ### Crashes are being posted too frequently
 
@@ -62,8 +62,8 @@ Newer versions of symbol-upload and SendPdbs can be found on our [Downloads](int
 
 ### Max File Size Limit Exceeded
 
-By default, BugSplat will reject a request to upload any symbol file larger than 4 GB. This is a soft limit that our support team can raise. If you need to support an application with a symbol file greater than 4 GB please contact [support@bugsplat.com](mailto:support@bugsplat.com).
+By default, BugSplat will reject a request to upload any symbol file larger than 25 GB. This is a soft limit that our support team can raise. If you need to support an application with a symbol file greater than 25 GB please contact [support@bugsplat.com](mailto:support@bugsplat.com).
 
 **Table Max Size Limit Exceeded**
 
-By default, BugSplat will reject a request to upload symbols to a symbol store that will cause it to exceed a size of 8 GB. We reject symbol stores over 8 GB to encourage users to upload each build to a new symbol store (instead of uploading all builds to the same symbol store). You can create as many symbol stores as you like.
+By default, BugSplat will reject a request to upload symbols to a symbol store that will cause it to exceed a size of 100 GB. We reject symbol stores over 100 GB to encourage users to upload each build to a new symbol store (instead of uploading all builds to the same symbol store). You can create as many symbol stores as you like.


### PR DESCRIPTION
Applies verified fixes from the July 2026 docs audit to **7 pages** in this section.

Every change is grounded in the current state of the product code or SDK repos (the audit findings carry file:line evidence). Screenshot/media updates are **not** in this PR — those are deferred to a separate follow-up.

## Pages fixed

- `introduction/getting-started/adding-uses-to-your-account.md` (#247)
- `introduction/getting-started/create-a-new-database-in-bugsplat.md` (#248)
- `introduction/getting-started/posting-a-test-crash/README.md` (#280)
- `introduction/getting-started/posting-a-test-crash/myconsolecrasher-c-plus-plus/address-sanitizer-reports.md` (#281)
- `introduction/getting-started/quickly-submitting-your-first-crash-in-under-5-minutes.md` (#282)
- `introduction/getting-started/signing-up-for-an-account-with-bugsplat.md` (#283)
- `introduction/getting-started/troubleshooting.md` (#284)

## Closes

Fixes #247
Fixes #248
Fixes #280
Fixes #281
Fixes #282
Fixes #283
Fixes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)