### PR TITLE
docs(api): document nUploaded fields added to API responses

### DIFF
--- a/introduction/development/web-services/api/charting.md
+++ b/introduction/development/web-services/api/charting.md
@@ -33,6 +33,7 @@ This endpoint is deprecated and may be removed in the future. Use the [Dashboard
 {
     "TotalRows": 1,
     "TotalCrashes": 20,
+    "TotalUploaded": 18,
     "StartDay": 738387,
     "EndDay": 738388,
     "Rows": [
@@ -44,14 +45,16 @@ This endpoint is deprecated and may be removed in the future. Use the [Dashboard
                     "timestamp": 1629417600,
                     "totalCrashCount": 20,
                     "throttleCrashCount": 0,
-                    "retireCrashCount": 0
+                    "retireCrashCount": 0,
+                    "uploadedCount": 18
                 },
                 {
                     "day": 738388,
                     "timestamp": 1629504000,
                     "totalCrashCount": 0,
                     "throttleCrashCount": 0,
-                    "retireCrashCount": 0
+                    "retireCrashCount": 0,
+                    "uploadedCount": 0
                 }
             ]
         }

--- a/introduction/development/web-services/api/dashboard.md
+++ b/introduction/development/web-services/api/dashboard.md
@@ -31,10 +31,12 @@ Returns a consolidated dashboard summary for the specified database and time ran
     "status": "success",
     "database": "Fred",
     "volume30Day": 1234,
+    "uploaded30Day": 1100,
     "crashDataDays": 45,
     "crashHistory": {
         "totalRows": 1,
         "totalCrashes": 500,
+        "totalUploaded": 480,
         "rows": [
             {
                 "appName": "All",
@@ -42,7 +44,8 @@ Returns a consolidated dashboard summary for the specified database and time ran
                     {
                         "day": 738387,
                         "timestamp": 1629417600,
-                        "totalCrashCount": 20
+                        "totalCrashCount": 20,
+                        "uploadedCount": 18
                     }
                 ]
             }
@@ -97,9 +100,10 @@ Returns a consolidated dashboard summary for the specified database and time ran
 | ------------- | ------ | --------------------------------------------------------------------------------------------- |
 | status        | string | `"success"` on success                                                                        |
 | database      | string | The database name                                                                             |
-| volume30Day   | number | Total crash count in the last 30 days                                                         |
+| volume30Day   | number | Total crash count in the last 30 days, counted when reports are accepted for upload. Includes reports that never finished uploading |
+| uploaded30Day | number | Number of crash reports that completed upload and were stored in the last 30 days. May be lower than `volume30Day` when clients abandon uploads |
 | crashDataDays | number | Number of days of crash data available                                                        |
-| crashHistory  | object | Chart data for crash volume over time. Contains `totalRows`, `totalCrashes`, and `rows` array |
+| crashHistory  | object | Chart data for crash volume over time. Contains `totalRows`, `totalCrashes`, `totalUploaded`, and `rows` array. Each series entry contains `totalCrashCount` and `uploadedCount` |
 | lastCrashTime | string | ISO 8601 timestamp of the most recent crash overall, not limited by the requested time range or filters. `null` if no crashes exist |
 | recentCrashes | array  | The 5 most recent crashes in the time range                                                   |
 | statusCounts  | object | Crash group status breakdown for `current` and `previous` time periods                        |

--- a/introduction/development/web-services/api/versions.md
+++ b/introduction/development/web-services/api/versions.md
@@ -21,8 +21,8 @@ Returns a list of versions in a given database.
 | Name                  | Type   | Description                                                                   |
 | --------------------- | ------ | ------------------------------------------------------------------------------ |
 | database              | string | BugSplat database containing symbol stores                                    |
-| crashCountStartDate   | string | Optional start date used to compute periodCrashCount for the returned versions |
-| crashCountEndDate     | string | Optional end date used to compute periodCrashCount for the returned versions   |
+| crashCountStartDate   | string | Optional start date used to compute periodCrashCount and periodUploadedCount for the returned versions |
+| crashCountEndDate     | string | Optional end date used to compute periodCrashCount and periodUploadedCount for the returned versions   |
 
 {% tabs %}
 {% tab title="200 " %}
@@ -44,7 +44,8 @@ Returns a list of versions in a given database.
       "rejectedCount": "0",
       "retired": "0",
       "totalCrashCount": "0",
-      "periodCrashCount": "0"
+      "periodCrashCount": "0",
+      "periodUploadedCount": "0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

BugSplat-Git/webroot#1824 added uploaded-report counts (`nUploaded`) to several API responses. This PR documents the new fields on the docs pages that cover those endpoints.

- **Dashboard** (`GET /api/dashboard`): new top-level `uploaded30Day`, `crashHistory.totalUploaded`, and `uploadedCount` on each series entry. Also clarifies the distinction: `volume30Day` counts reports as they are accepted for upload (including uploads that never complete), while `uploaded30Day` counts reports that finished uploading and were stored.
- **Deprecated → Crash History** (`GET /api/crashHistory`): new `TotalUploaded` and per-bucket `uploadedCount` — the deprecated endpoint shares the same query functions, so its response gained the fields too.
- **Versions** (`GET /api/v2/versions`): new `periodUploadedCount` row field, computed over the same `crashCountStartDate`/`crashCountEndDate` range as `periodCrashCount`.

All fields are additive; no existing fields changed.

Not documented here because the endpoints have no docs pages today: `GET /api/databaseDetails` (new `Volume30DayUploaded`/`Volume365DayUploaded`) and `GET /api/subscription` (new `volume30DayUploaded`/`volume365DayUploaded`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)