### PR TITLE
docs(api): document throttleCrashCount and retireCrashCount in the dashboard series

### DIFF
--- a/introduction/development/web-services/api/dashboard.md
+++ b/introduction/development/web-services/api/dashboard.md
@@ -45,6 +45,8 @@ Returns a consolidated dashboard summary for the specified database and time ran
                         "day": 738387,
                         "timestamp": 1629417600,
                         "totalCrashCount": 20,
+                        "throttleCrashCount": 2,
+                        "retireCrashCount": 0,
                         "uploadedCount": 18
                     }
                 ]
@@ -103,7 +105,7 @@ Returns a consolidated dashboard summary for the specified database and time ran
 | volume30Day   | number | Total crash count in the last 30 days, counted when reports are accepted for upload. Includes reports that never finished uploading |
 | uploaded30Day | number | Number of crash reports that completed upload and were stored in the last 30 days. May be lower than `volume30Day` when clients abandon uploads |
 | crashDataDays | number | Number of days of crash data available                                                        |
-| crashHistory  | object | Chart data for crash volume over time. Contains `totalRows`, `totalCrashes`, `totalUploaded`, and `rows` array. Each series entry contains `totalCrashCount` and `uploadedCount` |
+| crashHistory  | object | Chart data for crash volume over time. Contains `totalRows`, `totalCrashes`, `totalUploaded`, and `rows` array. Each series entry contains `totalCrashCount`, `throttleCrashCount`, `retireCrashCount`, and `uploadedCount`. `totalCrashCount` already includes the throttled reports, so accepted-for-upload reports are `totalCrashCount - throttleCrashCount` |
 | lastCrashTime | string | ISO 8601 timestamp of the most recent crash overall, not limited by the requested time range or filters. `null` if no crashes exist |
 | recentCrashes | array  | The 5 most recent crashes in the time range                                                   |
 | statusCounts  | object | Crash group status breakdown for `current` and `previous` time periods                        |


### PR DESCRIPTION
## Why

On the [Dashboard API](https://docs.bugsplat.com/introduction/development/web-services/api/dashboard#dashboard-summary) page, the `crashHistory` series entries in the sample response only listed `totalCrashCount` and `uploadedCount`. But the API has **always** returned `throttleCrashCount` and `retireCrashCount` per bucket too — they're what the response's top-level `totalThrottled` is summed from (`dashboard.php` reads `throttleCrashCount` back out of the series). They were just never documented, so the throttled count in the series looked missing.

## What

Documentation only — no API change:

- Added `throttleCrashCount` and `retireCrashCount` to the sample series entry
- Extended the `crashHistory` field-table description to list all four per-bucket fields
- Noted that `totalCrashCount` already includes the throttled reports, so accepted-for-upload = `totalCrashCount - throttleCrashCount`

Verified the field names against `api/crashHistory_fns.php` (daily and hourly both set all four), and the sample response still parses as valid JSON.

## Not included

The `throttled30Day` top-level scalar (webroot#1850) is intentionally **left out** of this PR. It isn't deployed yet, and this site auto-publishes from `master`, so documenting it now would describe a field that returns `undefined` in production. It gets its own docs update once #1850 merges and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)